### PR TITLE
Removal of the support for the deprecated Store Channels

### DIFF
--- a/jda/src/main/java/revxrsal/commands/jda/core/JDAHandler.java
+++ b/jda/src/main/java/revxrsal/commands/jda/core/JDAHandler.java
@@ -34,7 +34,6 @@ public final class JDAHandler extends BaseCommandHandler implements JDACommandHa
         registerSnowflakeResolver(TextChannel.class, TEXT_CHANNEL);
         registerSnowflakeResolver(VoiceChannel.class, VOICE_CHANNEL);
         registerSnowflakeResolver(StageChannel.class, STAGE_CHANNEL);
-        registerSnowflakeResolver(StoreChannel.class, STORE_CHANNEL);
         registerSnowflakeResolver(Member.class, MEMBER);
         registerSnowflakeResolver(Emote.class, EMOTE);
         registerSnowflakeResolver(Role.class, ROLE);

--- a/jda/src/main/java/revxrsal/commands/jda/core/SnowflakeResolvers.java
+++ b/jda/src/main/java/revxrsal/commands/jda/core/SnowflakeResolvers.java
@@ -27,7 +27,6 @@ enum SnowflakeResolvers implements ValueResolver<ISnowflake> {
     TEXT_CHANNEL(Guild::getTextChannelById, Guild::getTextChannelsByName, InvalidChannelException::new),
     VOICE_CHANNEL(Guild::getVoiceChannelById, Guild::getVoiceChannelsByName, InvalidChannelException::new),
     STAGE_CHANNEL(Guild::getStageChannelById, Guild::getStageChannelsByName, InvalidChannelException::new),
-    STORE_CHANNEL(Guild::getStoreChannelById, Guild::getStoreChannelsByName, InvalidChannelException::new),
     EMOTE(Guild::getEmoteById, Guild::getEmotesByName, InvalidEmoteException::new),
     CATEGORY(Guild::getCategoryById, Guild::getCategoriesByName, InvalidCategoryException::new);
 


### PR DESCRIPTION
Starting at the release with number of v5.0.0-alpha.6, JDA removed the support for the now deprecated Store Channel.

Official Discord documentation containing the information about the Store Channel deprecation: https://discord.com/developers/docs/game-and-server-management/special-channels

If a person is using the JDA module of Lamp and a version of JDA that is equal to or higher than v5.0.0-alpha.6, it will get thrown an NoSuchMethodError related to the absence of the Store Channel's methods from the Guild class and the Store Channel class itself.

Pull request that proposes the removal of the Store Channel: https://github.com/DV8FromTheWorld/JDA/pull/2011
v5.0.0-alpha.6 release page: https://github.com/DV8FromTheWorld/JDA/releases/tag/v5.0.0-alpha.6

NoSuchMethodError example:
```
Exception in thread "main" java.lang.NoSuchMethodError: 'net.dv8tion.jda.api.entities.StoreChannel net.dv8tion.jda.api.entities.Guild.getStoreChannelById(java.lang.String)'
    at revxrsal.commands.jda.core.SnowflakeResolvers.<clinit>(SnowflakeResolvers.java:30)
```

Solution: with the removal of the Store Channel related features such as the enum constant (STORE_CHANNEL) from SnowflakeResolvers class and the snowflake registering statement from the JDAHandler class, the error should be fixed for the  v5.0.0-alpha.6+ releases. With the only downside being the drop of support for the store channel feature, which is deprecated and shouldn't be used anymore.