### PR TITLE
Fixed the jitpack build not being found

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,9 +1,9 @@
 plugins {
     id "java"
+    id "maven-publish"
 }
 
 subprojects {
-
     apply plugin: "java"
     apply plugin: "maven-publish"
 
@@ -12,6 +12,14 @@ subprojects {
 
     sourceCompatibility = 1.8
     targetCompatibility = 1.8
+
+    publishing {
+        publications {
+            mavenJava(MavenPublication) {
+                from components.java
+            }
+        }
+    }
 
     repositories {
         mavenCentral()


### PR DESCRIPTION
At the moment, the 3.0.1 release is currently not available on JitPack due to the error below, this PR solves the following issue:
> ⚠️ ERROR: No build artifacts found
Expected artifacts in: $HOME/.m2/repository/io/github/revxrsal/bukkit/3.0.1

You can view the live result of this PR at https://jitpack.io/#Tofpu/Lamp/3.0.2