### PR TITLE
Fix MissingArgumentException was not thrown with unspecified flag

### DIFF
--- a/common/src/main/java/revxrsal/commands/core/BaseCommandDispatcher.java
+++ b/common/src/main/java/revxrsal/commands/core/BaseCommandDispatcher.java
@@ -183,7 +183,7 @@ public final class BaseCommandDispatcher {
             }
         } else {
             args.remove(index); // remove the flag prefix + flag name
-            if (args.isEmpty())
+            if (index>=args.size())
                 throw new MissingArgumentException(parameter);
             flagArguments = ArgumentStack.of(args.remove(index)); // put the actual value in a separate argument stack
         }


### PR DESCRIPTION
Example:
```
@Command("example")
public class ExampleCommand implements OrphanCommand {

	@Default
	public void onCommand(CommandActor actor,
			@Default("1") String anyArgument, @Flag("type") @Optional String type) {
		actor.reply("test");
	}
}
```
And if i write:
**/example anyText -type**
It will throw IndexOutOfBoundsException, not MissingArgumentException.

Stacktrace:
<big><pre>java.lang.IndexOutOfBoundsException: Index: 1, Size: 1
  at java.util.LinkedList.checkElementIndex(Unknown Source)
  at java.util.LinkedList.remove(Unknown Source)
  at revxrsal.commands.core.BaseCommandDispatcher.handleFlag([BaseCommandDispatcher.java:188](https://github.com/Revxrsal/Lamp/blob/dba5927641a0b4a45d7a6e3fbbe343ea21526069/common/src/main/java/revxrsal/commands/core/BaseCommandDispatcher.java#L188))
  at revxrsal.commands.core.BaseCommandDispatcher.getMethodArguments([BaseCommandDispatcher.java:105](https://github.com/Revxrsal/Lamp/blob/dba5927641a0b4a45d7a6e3fbbe343ea21526069/common/src/main/java/revxrsal/commands/core/BaseCommandDispatcher.java#L105))
  at revxrsal.commands.core.BaseCommandDispatcher.execute([BaseCommandDispatcher.java:82](https://github.com/Revxrsal/Lamp/blob/dba5927641a0b4a45d7a6e3fbbe343ea21526069/common/src/main/java/revxrsal/commands/core/BaseCommandDispatcher.java#L82))
  at revxrsal.commands.core.BaseCommandDispatcher.searchCategory([BaseCommandDispatcher.java:69](https://github.com/Revxrsal/Lamp/blob/dba5927641a0b4a45d7a6e3fbbe343ea21526069/common/src/main/java/revxrsal/commands/core/BaseCommandDispatcher.java#L69))
  at revxrsal.commands.core.BaseCommandDispatcher.eval([BaseCommandDispatcher.java:44](https://github.com/Revxrsal/Lamp/blob/dba5927641a0b4a45d7a6e3fbbe343ea21526069/common/src/main/java/revxrsal/commands/core/BaseCommandDispatcher.java#L44))
  at revxrsal.commands.core.BaseCommandHandler.dispatch([BaseCommandHandler.java:475](https://github.com/Revxrsal/Lamp/blob/dba5927641a0b4a45d7a6e3fbbe343ea21526069/common/src/main/java/revxrsal/commands/core/BaseCommandHandler.java#L475))</pre></big>
  
  
  And i just replaced args.isEmpty with index check. And it`s working in the expected way.