### PR TITLE
minor "no-subcommand-specified" translation fix

### DIFF
--- a/common/src/main/resources/lamp_pt.properties
+++ b/common/src/main/resources/lamp_pt.properties
@@ -15,6 +15,6 @@ missing-argument=Voc\u00EA deve especificar um valor para o(a) {0}!
 no-permission=Voc\u00EA n\u00E3o tem permiss\u00E3o para executar esse comando.
 error-occurred=Ocorreu um erro ao tentar executar esse comando.
 too-many-arguments=H\u00E1 argumentos demais! Forma correta de uso: /{0}
-no-subcommand-specified=Voc\u00EA n\u00E3o deve especificar um subcomando!
+no-subcommand-specified=Voc\u00EA deve especificar um subcomando!
 on-cooldown=Voc\u00EA deve esperar {0} at\u00E9 usar esse comando novamente.
 number-not-in-range={0} tem que ser entre {1} \u00E0 {2} (encontrado {3})


### PR DESCRIPTION
Correction to the small spelling mistake the first English version had.