### PR TITLE
add NamespacedKey resolver

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ subprojects {
     apply plugin: "maven-publish"
 
     group = "io.github.revxrsal"
-    version = "3.0.3" 
+    version = "3.0.4-SNAPSHOT"
 
     sourceCompatibility = 1.8
     targetCompatibility = 1.8

--- a/bukkit/src/main/java/revxrsal/commands/bukkit/core/BukkitBrigadier.java
+++ b/bukkit/src/main/java/revxrsal/commands/bukkit/core/BukkitBrigadier.java
@@ -58,6 +58,7 @@ final class BukkitBrigadier implements LampBrigadier {
         argumentTypes.add(Player.class, entity(true, true));
         argumentTypes.add(EntitySelector.class, entity(false, false));
         argumentTypes.add(EntityType.class, MinecraftArgumentTypes.getByKey(NamespacedKey.minecraft("entity_summon")));
+        argumentTypes.add(NamespacedKey.class, MinecraftArgumentTypes.getByKey(NamespacedKey.minecraft("resource_location")));
     }
 
     @Override public @NotNull CommandActor wrapSource(@NotNull Object commandSource) {

--- a/bukkit/src/main/java/revxrsal/commands/bukkit/core/BukkitHandler.java
+++ b/bukkit/src/main/java/revxrsal/commands/bukkit/core/BukkitHandler.java
@@ -4,6 +4,7 @@ import com.google.common.base.Suppliers;
 import lombok.SneakyThrows;
 import me.lucko.commodore.CommodoreProvider;
 import org.bukkit.Bukkit;
+import org.bukkit.NamespacedKey;
 import org.bukkit.OfflinePlayer;
 import org.bukkit.World;
 import org.bukkit.command.Command;
@@ -27,6 +28,7 @@ import revxrsal.commands.bukkit.BukkitCommandActor;
 import revxrsal.commands.bukkit.BukkitCommandHandler;
 import revxrsal.commands.bukkit.core.EntitySelectorResolver.SelectorSuggestionFactory;
 import revxrsal.commands.bukkit.exception.BukkitExceptionAdapter;
+import revxrsal.commands.bukkit.exception.InvalidNamespacedKeyException;
 import revxrsal.commands.bukkit.exception.InvalidPlayerException;
 import revxrsal.commands.bukkit.exception.InvalidWorldException;
 import revxrsal.commands.command.CommandCategory;
@@ -98,6 +100,17 @@ public final class BukkitHandler extends BaseCommandHandler implements BukkitCom
             if (type == null)
                 throw new EnumNotFoundException(context.parameter(), value);
             return type;
+        });
+        registerValueResolver(NamespacedKey.class, context -> {
+            final String value = context.pop();
+            final String[] split = value.split(":", 2);
+            if (split.length != 2) throw new InvalidNamespacedKeyException(context.parameter(), value);
+            // Further validation is done by Bukkit so we can try-catch to avoid running validation process twice
+            try {
+                return new NamespacedKey(split[0], split[1]); // Deprecation should be safe to ignore
+            } catch (final IllegalArgumentException e) {
+                throw new InvalidNamespacedKeyException(context.parameter(), value);
+            }
         });
         if (EntitySelectorResolver.INSTANCE.supportsComplexSelectors() && brigadier.get().isPresent())
             getAutoCompleter().registerParameterSuggestions(EntityType.class, SuggestionProvider.EMPTY);

--- a/bukkit/src/main/java/revxrsal/commands/bukkit/exception/BukkitExceptionAdapter.java
+++ b/bukkit/src/main/java/revxrsal/commands/bukkit/exception/BukkitExceptionAdapter.java
@@ -27,4 +27,8 @@ public class BukkitExceptionAdapter extends DefaultExceptionHandler {
     public void malformedEntitySelector(@NotNull CommandActor actor, @NotNull MalformedEntitySelectorException exception) {
         actor.errorLocalized("invalid-selector", exception.getInput());
     }
+
+    public void invalidNamespacedKey(@NotNull final CommandActor actor, @NotNull final InvalidNamespacedKeyException exception) {
+        actor.errorLocalized("invalid-namespacedkey", exception.getInput());
+    }
 }

--- a/bukkit/src/main/java/revxrsal/commands/bukkit/exception/InvalidNamespacedKeyException.java
+++ b/bukkit/src/main/java/revxrsal/commands/bukkit/exception/InvalidNamespacedKeyException.java
@@ -1,0 +1,15 @@
+package revxrsal.commands.bukkit.exception;
+
+import org.jetbrains.annotations.NotNull;
+import revxrsal.commands.command.CommandParameter;
+import revxrsal.commands.exception.InvalidValueException;
+
+/**
+ * Thrown when an invalid value for a {@link org.bukkit.NamespacedKey} parameter is inputted in the command
+ */
+public class InvalidNamespacedKeyException extends InvalidValueException {
+
+    public InvalidNamespacedKeyException(@NotNull final CommandParameter parameter, @NotNull final String input) {
+        super(parameter, input);
+    }
+}

--- a/bukkit/src/main/resources/lamp-bukkit_en.properties
+++ b/bukkit/src/main/resources/lamp-bukkit_en.properties
@@ -3,3 +3,4 @@ must-be-console=This command can only be used on console!
 invalid-player=Invalid player: &e{0}
 invalid-world=Invalid world: &e{0}
 invalid-selector=Invalid selector argument: &e{0}
+invalid-namespacedkey=Invalid namespaced key: &e{0}


### PR DESCRIPTION
this PR adds value resolver for `org.bukkit.NamespacedKey` with `resource_location` brigadier type to support nice client-side formatting

bumped Lamp version to 3.0.4-SNAPSHOT