### PR TITLE
Update `@DefaultFor` Documentation (#46)

### DIFF
--- a/common/src/main/java/revxrsal/commands/annotation/DefaultFor.java
+++ b/common/src/main/java/revxrsal/commands/annotation/DefaultFor.java
@@ -13,10 +13,10 @@ import java.lang.annotation.Target;
  * <p>
  * This example shows a common use case for this annotation:
  * <pre>{@code
- * @Command("test")
+ * @Command({"test", "testing"})
  * public class TestCommand {
  *
- *     @DefaultFor("test") // <--- Becomes the default action when running '/test [page]'
+ *     @DefaultFor({"test", "testing"}) // <--- Becomes the default action when running '/test [page]' AND '/testing [page]'; Both aliases are required in order to work
  *     @Subcommand("help") // <--- Also executes in '/test help [page]'
  *     public void help(@Optional(def = "1") int page) {
  *         ...


### PR DESCRIPTION
Hello,

As specified in #46, all aliases must be inputted in order for sub-commands on a command to work.
I've updated the documentation to reflect this change, but this should only be merged if @Revxrsal decides to not change the functionality.

Thanks 🙂