### PR TITLE
Add feature for referencing parent path in @DefaultFor with prefix

### DIFF
--- a/common/src/main/java/revxrsal/commands/CommandHandler.java
+++ b/common/src/main/java/revxrsal/commands/CommandHandler.java
@@ -26,6 +26,7 @@ package revxrsal.commands;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.jetbrains.annotations.UnmodifiableView;
+import revxrsal.commands.annotation.DefaultFor;
 import revxrsal.commands.annotation.Dependency;
 import revxrsal.commands.annotation.Flag;
 import revxrsal.commands.annotation.Switch;
@@ -154,6 +155,18 @@ public interface CommandHandler {
      * @return This command handler
      */
     @NotNull CommandHandler setMessagePrefix(@NotNull String prefix);
+
+    /**
+     * Sets the prefix that all method annotated with {@link DefaultFor}
+     * for using parent path. If not set, <blockquote>~</blockquote> will be used.
+     * <p>
+     * This is useful for Orphan commands.
+     *
+     * @param prefix New prefix to set
+     * @return This command handler
+     * @throws IllegalArgumentException if the prefix is empty
+     */
+    @NotNull CommandHandler setParentPathPrefix(@NotNull String prefix);
 
     /**
      * Sets the {@link CommandHelpWriter} responsible for generating help pages
@@ -559,6 +572,14 @@ public interface CommandHandler {
      * @return The message prefix
      */
     @NotNull String getMessagePrefix();
+
+    /**
+     * Returns the prefix that comes for {@link DefaultFor}
+     * when defining parent path.
+     *
+     * @return The parent path prefix
+     */
+    @NotNull String getParentPathPrefix();
 
     /**
      * Returns the dependency registered for the given type

--- a/common/src/main/java/revxrsal/commands/core/BaseCommandHandler.java
+++ b/common/src/main/java/revxrsal/commands/core/BaseCommandHandler.java
@@ -97,7 +97,7 @@ public abstract class BaseCommandHandler implements CommandHandler {
     private MethodCallerFactory methodCallerFactory = MethodCallerFactory.defaultFactory();
     private final WrappedExceptionHandler exceptionHandler = new WrappedExceptionHandler(DefaultExceptionHandler.INSTANCE);
     private StackTraceSanitizer sanitizer = StackTraceSanitizer.defaultSanitizer();
-    String flagPrefix = "-", switchPrefix = "-", messagePrefix = "";
+    String flagPrefix = "-", switchPrefix = "-", messagePrefix = "", parentPathPrefix = "~";
     CommandHelpWriter<?> helpWriter;
     ParameterNamingStrategy parameterNamingStrategy = ParameterNamingStrategy.lowerCaseWithSpace();
     boolean failOnExtra = false;
@@ -266,6 +266,13 @@ public abstract class BaseCommandHandler implements CommandHandler {
     @Override public @NotNull CommandHandler setMessagePrefix(@NotNull String prefix) {
         notNull(prefix, "prefix");
         messagePrefix = prefix;
+        return this;
+    }
+
+    @Override
+    public @NotNull CommandHandler setParentPathPrefix(@NotNull String prefix) {
+        notNull(prefix, "parentPath");
+        parentPathPrefix = prefix;
         return this;
     }
 
@@ -534,6 +541,10 @@ public abstract class BaseCommandHandler implements CommandHandler {
 
     @Override public @NotNull String getMessagePrefix() {
         return messagePrefix;
+    }
+
+    @Override public @NotNull String getParentPathPrefix() {
+        return parentPathPrefix;
     }
 
     @Override public <T> @NotNull Optional<@Nullable T> dispatch(@NotNull CommandActor actor, @NotNull ArgumentStack arguments) {


### PR DESCRIPTION
This would help creating OrphanCommand with @DefaultFor annotation.
We can easily reference like: \\@DefaultFor("~"), and it would take parent path.

For example:
```java
@Command("simple")
public class SimpleCommand {
    @DefaultFor("~")
    public void onCommand(){
        // executed when /simple dispatched 
    }
    
    @DefaultFor({"~", "test"}) // I think it will behavior like subcommand
    public void onTestCommand(){
       // executed when /simple test dispatched
    }
    
    @DefaultFor({"too","~"}) // Its like subcommand, but revesed
    public void onTooCommand(){
       // executed when /too simple dispatched
    }
}
```

And yes, like that command will be invalid and throw 
```java
@Command("simple")
public class SimpleCommand {
    @DefaultFor("~")
    public void onCommand(){
        // executed when /simple dispatched
    }

    @DefaultFor({"~", "test"}) // I think it will behavior like subcommand
    public void onTestCommand(){
        // executed when /simple test dispatched
    }

    @DefaultFor({"too","~"}) // Its like subcommand, but reversed
    public void onTooCommand(){
        // executed when /too simple dispatched
    }

    @DefaultFor("simple")
    public void onInvalidCommand(){
        // executed when /simple dispatched
    }
}
```

Exception:
```java
Exception in thread "main" java.lang.IllegalArgumentException: Category 'simple' has more than one default action! (public void SimpleCommand.onCommand() and public void SimpleCommand.onInvalidCommand())
	at revxrsal.commands.core.CommandExecutable.parent(CommandExecutable.java:158)
	at revxrsal.commands.core.CommandParser.lambda$parse$4(CommandParser.java:177)
	at java.util.ArrayList.forEach(ArrayList.java:1259)
	at revxrsal.commands.core.CommandParser.parse(CommandParser.java:152)
	at revxrsal.commands.core.CommandParser.parse(CommandParser.java:106)
	at revxrsal.commands.core.BaseCommandHandler.register(BaseCommandHandler.java:188)
```