### PR TITLE
OfflinePlayer resolver

### DIFF
--- a/bukkit/src/main/java/revxrsal/commands/bukkit/core/BukkitHandler.java
+++ b/bukkit/src/main/java/revxrsal/commands/bukkit/core/BukkitHandler.java
@@ -101,7 +101,7 @@ public final class BukkitHandler extends BaseCommandHandler implements BukkitCom
             if (value.equalsIgnoreCase("self") || value.equalsIgnoreCase("me"))
                 return ((BukkitCommandActor) context.actor()).requirePlayer();
             OfflinePlayer player = Bukkit.getOfflinePlayer(value);
-            if (!player.hasPlayedBefore())
+            if (!player.hasPlayedBefore() && !player.isOnline())
                 throw new InvalidPlayerException(context.parameter(), value);
             return player;
         });


### PR DESCRIPTION
Currently, in the OfflinePlayer resolver, a check is made to see if the player has played before. However, for new players who have just registered, the method returns false and it turns out that the command tends not to work for these new players.