### PR TITLE
Fixing redundant check

### DIFF
--- a/common/src/main/java/revxrsal/commands/core/BaseCommandDispatcher.java
+++ b/common/src/main/java/revxrsal/commands/core/BaseCommandDispatcher.java
@@ -162,16 +162,11 @@ public final class BaseCommandDispatcher {
                                      CommandParameter parameter,
                                      Object[] values) {
         if (args.isEmpty()) {
-            if (parameter.getDefaultValue().isEmpty()) {
-                values[parameter.getMethodIndex()] = null;
-                return true;
+            if (!parameter.getDefaultValue().isEmpty()) {
+                args.addAll(parameter.getDefaultValue());
+                return false;
             } else {
-                if (!parameter.getDefaultValue().isEmpty()) {
-                    args.addAll(parameter.getDefaultValue());
-                    return false;
-                } else {
-                    throw new MissingArgumentException(parameter);
-                }
+                throw new MissingArgumentException(parameter);
             }
         }
         return false;

--- a/common/src/main/java/revxrsal/commands/core/CommandParser.java
+++ b/common/src/main/java/revxrsal/commands/core/CommandParser.java
@@ -369,6 +369,7 @@ final class CommandParser {
                 if (defaultValue != null && defaultValue.length == 1 && defaultValue[0].equals("<?null>"))
                     defaultValue = null;
             }
+
             BaseCommandParameter param = new BaseCommandParameter(
                     paramAnns.get(Description.class, Description::value),
                     i,


### PR DESCRIPTION
In the last commit: [Fix Optional's def causing issues](https://github.com/Revxrsal/Lamp/commit/15212537897c3f68ba394711059dff2e4fddb94b) It has a redundancy in the checks, preventing the error of missing arguments from being called. This way, when using a command without putting the arguments, the values ​​are passed as null instead of sending missing arguments.

I partially fixed it by removing a piece of code that was previously removed. However, as I haven't tested all the features of the code, I don't know if it would cause any errors in the future, apparently it's working.