### PR TITLE
JDA Slash commands support. Backward compatible

### DIFF
--- a/jda/src/main/java/revxrsal/commands/jda/JDAActor.java
+++ b/jda/src/main/java/revxrsal/commands/jda/JDAActor.java
@@ -1,13 +1,23 @@
 package revxrsal.commands.jda;
 
-import net.dv8tion.jda.api.entities.*;
-import net.dv8tion.jda.api.entities.channel.middleman.MessageChannel;
-import net.dv8tion.jda.api.events.message.MessageReceivedEvent;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import net.dv8tion.jda.api.entities.Guild;
+import net.dv8tion.jda.api.entities.Member;
+import net.dv8tion.jda.api.entities.Message;
+import net.dv8tion.jda.api.entities.User;
+import net.dv8tion.jda.api.entities.channel.middleman.MessageChannel;
+import net.dv8tion.jda.api.events.Event;
+import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent;
+import net.dv8tion.jda.api.events.message.MessageReceivedEvent;
 import revxrsal.commands.CommandHandler;
 import revxrsal.commands.command.CommandActor;
 import revxrsal.commands.command.ExecutableCommand;
-import revxrsal.commands.jda.core.BaseActorJDA;
+import revxrsal.commands.jda.actor.MessageJDAActor;
+import revxrsal.commands.jda.actor.SlashJDAActor;
+import revxrsal.commands.jda.core.actor.BaseJDAMessageActor;
+import revxrsal.commands.jda.core.actor.BaseJDASlashActor;
 import revxrsal.commands.jda.exception.GuildOnlyCommandException;
 import revxrsal.commands.jda.exception.PrivateMessageOnlyCommandException;
 
@@ -16,6 +26,25 @@ import revxrsal.commands.jda.exception.PrivateMessageOnlyCommandException;
  * whether in a private message or a guild.
  */
 public interface JDAActor extends CommandActor {
+    /**
+     * Creates a new {@link JDAActor} that wraps the given {@link MessageReceivedEvent}.
+     *
+     * @param event Event to wrap
+     * @return The wrapping {@link JDAActor}.
+     */
+    static @NotNull MessageJDAActor wrap(@NotNull MessageReceivedEvent event, @NotNull CommandHandler handler) {
+        return new BaseJDAMessageActor(event, handler);
+    }
+
+    /**
+     * Creates a new {@link JDAActor} that wraps the given {@link SlashCommandInteractionEvent}.
+     *
+     * @param event Event to wrap
+     * @return The wrapping {@link JDAActor}.
+     */
+    static @NotNull SlashJDAActor wrap(@NotNull SlashCommandInteractionEvent event, @NotNull CommandHandler handler) {
+        return new BaseJDASlashActor(event, handler);
+    }
 
     /**
      * Returns the snowflake ID of this actor
@@ -42,16 +71,25 @@ public interface JDAActor extends CommandActor {
      * Returns the message of the actor
      *
      * @return The actor's sent message
+     * @deprecated As of Lamp 3.2.0, because of support slash commands use {@link MessageJDAActor#getMessage()}
      */
-    @NotNull Message getMessage();
+    @Deprecated
+    default @Nullable Message getMessage() {
+        return null;
+    }
 
     /**
      * Returns the {@link MessageReceivedEvent} that created this
-     * actor
+     * actor.
      *
      * @return The event
+     * @deprecated As of Lamp 3.2.0, because of support slash commands use
+     * {@link #getGenericEvent()} or {@link MessageJDAActor#getEvent()} instead.
      */
-    @NotNull MessageReceivedEvent getEvent();
+    @Deprecated
+    default @Nullable MessageReceivedEvent getEvent() {
+        return null;
+    }
 
     /**
      * Returns the channel this actor sent the command in

--- a/jda/src/main/java/revxrsal/commands/jda/JDAActor.java
+++ b/jda/src/main/java/revxrsal/commands/jda/JDAActor.java
@@ -9,6 +9,7 @@ import net.dv8tion.jda.api.entities.Message;
 import net.dv8tion.jda.api.entities.User;
 import net.dv8tion.jda.api.entities.channel.middleman.MessageChannel;
 import net.dv8tion.jda.api.events.Event;
+import net.dv8tion.jda.api.events.interaction.command.CommandAutoCompleteInteractionEvent;
 import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent;
 import net.dv8tion.jda.api.events.message.MessageReceivedEvent;
 import revxrsal.commands.CommandHandler;
@@ -16,6 +17,8 @@ import revxrsal.commands.command.CommandActor;
 import revxrsal.commands.command.ExecutableCommand;
 import revxrsal.commands.jda.actor.MessageJDAActor;
 import revxrsal.commands.jda.actor.SlashCommandJDAActor;
+import revxrsal.commands.jda.actor.SlashCommandSuggestionJDAActor;
+import revxrsal.commands.jda.core.actor.BaseJDACommandSuggestionActor;
 import revxrsal.commands.jda.core.actor.BaseJDAMessageActor;
 import revxrsal.commands.jda.core.actor.BaseJDASlashCommandActor;
 import revxrsal.commands.jda.exception.GuildOnlyCommandException;
@@ -44,6 +47,16 @@ public interface JDAActor extends CommandActor {
      */
     static @NotNull SlashCommandJDAActor wrap(@NotNull SlashCommandInteractionEvent event, @NotNull CommandHandler handler) {
         return new BaseJDASlashCommandActor(event, handler);
+    }
+
+    /**
+     * Creates a new {@link JDAActor} that wraps the given {@link CommandAutoCompleteInteractionEvent}.
+     *
+     * @param event Event to wrap
+     * @return The wrapping {@link JDAActor}.
+     */
+    static @NotNull SlashCommandSuggestionJDAActor wrap(@NotNull CommandAutoCompleteInteractionEvent event, @NotNull CommandHandler handler) {
+        return new BaseJDACommandSuggestionActor(event, handler);
     }
 
     /**

--- a/jda/src/main/java/revxrsal/commands/jda/JDAActor.java
+++ b/jda/src/main/java/revxrsal/commands/jda/JDAActor.java
@@ -15,9 +15,9 @@ import revxrsal.commands.CommandHandler;
 import revxrsal.commands.command.CommandActor;
 import revxrsal.commands.command.ExecutableCommand;
 import revxrsal.commands.jda.actor.MessageJDAActor;
-import revxrsal.commands.jda.actor.SlashJDAActor;
+import revxrsal.commands.jda.actor.SlashCommandJDAActor;
 import revxrsal.commands.jda.core.actor.BaseJDAMessageActor;
-import revxrsal.commands.jda.core.actor.BaseJDASlashActor;
+import revxrsal.commands.jda.core.actor.BaseJDASlashCommandActor;
 import revxrsal.commands.jda.exception.GuildOnlyCommandException;
 import revxrsal.commands.jda.exception.PrivateMessageOnlyCommandException;
 
@@ -42,8 +42,8 @@ public interface JDAActor extends CommandActor {
      * @param event Event to wrap
      * @return The wrapping {@link JDAActor}.
      */
-    static @NotNull SlashJDAActor wrap(@NotNull SlashCommandInteractionEvent event, @NotNull CommandHandler handler) {
-        return new BaseJDASlashActor(event, handler);
+    static @NotNull SlashCommandJDAActor wrap(@NotNull SlashCommandInteractionEvent event, @NotNull CommandHandler handler) {
+        return new BaseJDASlashCommandActor(event, handler);
     }
 
     /**
@@ -77,6 +77,13 @@ public interface JDAActor extends CommandActor {
     default @Nullable Message getMessage() {
         return null;
     }
+
+    /**
+     * Returns the {@link Event} that created this actor.
+     *
+     * @return The event
+     */
+    @NotNull Event getGenericEvent();
 
     /**
      * Returns the {@link MessageReceivedEvent} that created this
@@ -138,15 +145,4 @@ public interface JDAActor extends CommandActor {
      * @return This actor
      */
     JDAActor checkNotInGuild(ExecutableCommand command) throws PrivateMessageOnlyCommandException;
-
-    /**
-     * Creates a new {@link JDAActor} that wraps the given {@link MessageReceivedEvent}.
-     *
-     * @param event Event to wrap
-     * @return The wrapping {@link JDAActor}.
-     */
-    static @NotNull JDAActor wrap(@NotNull MessageReceivedEvent event, @NotNull CommandHandler handler) {
-        return new BaseActorJDA(event, handler);
-    }
-
 }

--- a/jda/src/main/java/revxrsal/commands/jda/JDACommandHandler.java
+++ b/jda/src/main/java/revxrsal/commands/jda/JDACommandHandler.java
@@ -1,7 +1,11 @@
 package revxrsal.commands.jda;
 
+import java.util.List;
+
 import net.dv8tion.jda.api.JDA;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.UnmodifiableView;
+
 import revxrsal.commands.CommandHandler;
 import revxrsal.commands.jda.core.JDAHandler;
 
@@ -16,6 +20,33 @@ public interface JDACommandHandler extends CommandHandler {
      * @return The JDA instance
      */
     @NotNull JDA getJDA();
+
+    /**
+     * Registers a {@link SlashCommandMapper} to this handler
+     *
+     * @param commandMapper Mapper to register
+     * @return This command handler
+     * @see SlashCommandMapper
+     */
+    @NotNull JDACommandHandler registerSlashCommandMapper(@NotNull SlashCommandMapper commandMapper);
+
+    /**
+     * Registers a {@link SlashCommandMapper} to this handler
+     *
+     * @param commandMapper Mapper to register
+     * @param priority The parser priority. Zero represents the highest.
+     * @return This command handler
+     * @see SlashCommandMapper
+     */
+    @NotNull JDACommandHandler registerSlashCommandMapper(int priority, @NotNull SlashCommandMapper commandMapper);
+
+    /**
+     * Returns an unmodifiable view of all the registered slash command parsers
+     * in this command handler.
+     *
+     * @return The registered slash command parsers
+     */
+    @NotNull @UnmodifiableView List<SlashCommandMapper> getSlashCommandMappers();
 
     /**
      * Creates a new {@link JDACommandHandler} for the given JDA instance.

--- a/jda/src/main/java/revxrsal/commands/jda/JDACommandHandler.java
+++ b/jda/src/main/java/revxrsal/commands/jda/JDACommandHandler.java
@@ -6,6 +6,7 @@ import net.dv8tion.jda.api.JDA;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.UnmodifiableView;
 
+import net.dv8tion.jda.api.interactions.commands.build.SlashCommandData;
 import revxrsal.commands.CommandHandler;
 import revxrsal.commands.jda.core.JDAHandler;
 
@@ -20,6 +21,14 @@ public interface JDACommandHandler extends CommandHandler {
      * @return The JDA instance
      */
     @NotNull JDA getJDA();
+
+    /**
+     * Registers a {@link SlashCommandData} using {@link JDA#updateCommands()}
+     *
+     * @return This command handler
+     * @see SlashCommandMapper
+     */
+    @NotNull JDACommandHandler registerSlashCommands();
 
     /**
      * Registers a {@link SlashCommandMapper} to this handler

--- a/jda/src/main/java/revxrsal/commands/jda/SlashCommandMapper.java
+++ b/jda/src/main/java/revxrsal/commands/jda/SlashCommandMapper.java
@@ -6,8 +6,15 @@ import revxrsal.commands.command.ExecutableCommand;
 import revxrsal.commands.jda.core.adapter.SlashCommandAdapter;
 
 /**
- * Maps {@link ExecutableCommand} into {@link }
+ * Modifies {@link SlashCommandAdapter} based on {@link ExecutableCommand}.
  */
 public interface SlashCommandMapper {
+    /**
+     *  Modifies existing slash command, or subcommand. For example changing description of slash commands.
+     *
+     * @param slashCommandAdapter Slash command or subcommand that will be modified
+     * @param command             Command that 'represents' slash command
+     * @see SlashCommandAdapter
+     */
     void mapSlashCommand(@NotNull SlashCommandAdapter slashCommandAdapter, @NotNull ExecutableCommand command);
 }

--- a/jda/src/main/java/revxrsal/commands/jda/SlashCommandMapper.java
+++ b/jda/src/main/java/revxrsal/commands/jda/SlashCommandMapper.java
@@ -1,0 +1,13 @@
+package revxrsal.commands.jda;
+
+import org.jetbrains.annotations.NotNull;
+
+import revxrsal.commands.command.ExecutableCommand;
+import revxrsal.commands.jda.core.adapter.SlashCommandAdapter;
+
+/**
+ * Maps {@link ExecutableCommand} into {@link }
+ */
+public interface SlashCommandMapper {
+    void mapSlashCommand(@NotNull SlashCommandAdapter slashCommandAdapter, @NotNull ExecutableCommand command);
+}

--- a/jda/src/main/java/revxrsal/commands/jda/actor/MessageJDAActor.java
+++ b/jda/src/main/java/revxrsal/commands/jda/actor/MessageJDAActor.java
@@ -1,0 +1,30 @@
+package revxrsal.commands.jda.actor;
+
+import org.jetbrains.annotations.NotNull;
+
+import net.dv8tion.jda.api.entities.Message;
+import net.dv8tion.jda.api.events.message.MessageReceivedEvent;
+import revxrsal.commands.jda.JDAActor;
+
+public interface MessageJDAActor extends JDAActor {
+    /**
+     * Returns the message of the actor
+     *
+     * @return The actor's sent message
+     */
+    @Override
+    default @NotNull Message getMessage() {
+        return getEvent().getMessage();
+    }
+
+    /**
+     * Returns the {@link MessageReceivedEvent} that created this
+     * actor.
+     *
+     * @return The event
+     */
+    @Override
+    default @NotNull MessageReceivedEvent getEvent() {
+        return (MessageReceivedEvent) getGenericEvent();
+    }
+}

--- a/jda/src/main/java/revxrsal/commands/jda/actor/MessageJDAActor.java
+++ b/jda/src/main/java/revxrsal/commands/jda/actor/MessageJDAActor.java
@@ -18,8 +18,7 @@ public interface MessageJDAActor extends JDAActor {
     }
 
     /**
-     * Returns the {@link MessageReceivedEvent} that created this
-     * actor.
+     * Returns the cast result of {@link #getGenericEvent()} to {@link MessageReceivedEvent}.
      *
      * @return The event
      */

--- a/jda/src/main/java/revxrsal/commands/jda/actor/SlashCommandJDAActor.java
+++ b/jda/src/main/java/revxrsal/commands/jda/actor/SlashCommandJDAActor.java
@@ -9,16 +9,6 @@ import net.dv8tion.jda.api.requests.restaction.interactions.ReplyCallbackAction;
 import revxrsal.commands.jda.JDAActor;
 
 public interface SlashCommandJDAActor extends JDAActor {
-    @Override
-    default void reply(@NotNull String message) {
-        getSlashEvent().reply(getCommandHandler().getMessagePrefix() + message).queue();
-    }
-
-    @Override
-    default void error(@NotNull String message) {
-        getSlashEvent().reply(getCommandHandler().getMessagePrefix() + message).queue();
-    }
-
     /**
      * Returns the ReplyCallbackAction. You should use {@link ReplyCallbackAction#queue()}, for sending 'thinking...' action
      *

--- a/jda/src/main/java/revxrsal/commands/jda/actor/SlashCommandJDAActor.java
+++ b/jda/src/main/java/revxrsal/commands/jda/actor/SlashCommandJDAActor.java
@@ -9,6 +9,16 @@ import net.dv8tion.jda.api.requests.restaction.interactions.ReplyCallbackAction;
 import revxrsal.commands.jda.JDAActor;
 
 public interface SlashCommandJDAActor extends JDAActor {
+    @Override
+    default void reply(@NotNull String message) {
+        getSlashEvent().reply(getCommandHandler().getMessagePrefix() + message).queue();
+    }
+
+    @Override
+    default void error(@NotNull String message) {
+        getSlashEvent().reply(getCommandHandler().getMessagePrefix() + message).queue();
+    }
+
     /**
      * Returns the ReplyCallbackAction. You should use {@link ReplyCallbackAction#queue()}, for sending 'thinking...' action
      *

--- a/jda/src/main/java/revxrsal/commands/jda/actor/SlashCommandJDAActor.java
+++ b/jda/src/main/java/revxrsal/commands/jda/actor/SlashCommandJDAActor.java
@@ -1,0 +1,48 @@
+package revxrsal.commands.jda.actor;
+
+import org.jetbrains.annotations.NotNull;
+
+import net.dv8tion.jda.api.entities.channel.unions.MessageChannelUnion;
+import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent;
+import net.dv8tion.jda.api.interactions.commands.SlashCommandInteraction;
+import net.dv8tion.jda.api.requests.restaction.interactions.ReplyCallbackAction;
+import revxrsal.commands.jda.JDAActor;
+
+public interface SlashCommandJDAActor extends JDAActor {
+    /**
+     * Returns the ReplyCallbackAction. You should use {@link ReplyCallbackAction#queue()}, for sending 'thinking...' action
+     *
+     * @return The actor's message channel union
+     */
+    default ReplyCallbackAction deferReply() {
+        return getSlashEvent().deferReply();
+    }
+
+    /**
+     * Returns the messsage channel union of the actor
+     *
+     * @return The actor's message channel union
+     */
+    default MessageChannelUnion getChannelUnion() {
+        return getSlashEvent().getChannel();
+    }
+
+    /**
+     * Returns the interaction of the actor
+     *
+     * @return The actor's sent message
+     */
+    default @NotNull SlashCommandInteraction getInteraction() {
+        return getSlashEvent().getInteraction();
+    }
+
+    /**
+     * Returns the {@link SlashCommandInteractionEvent} that created this
+     * actor.
+     *
+     * @return The event
+     */
+    default @NotNull SlashCommandInteractionEvent getSlashEvent() {
+        return (SlashCommandInteractionEvent) getGenericEvent();
+    }
+}

--- a/jda/src/main/java/revxrsal/commands/jda/actor/SlashCommandJDAActor.java
+++ b/jda/src/main/java/revxrsal/commands/jda/actor/SlashCommandJDAActor.java
@@ -37,8 +37,7 @@ public interface SlashCommandJDAActor extends JDAActor {
     }
 
     /**
-     * Returns the {@link SlashCommandInteractionEvent} that created this
-     * actor.
+     * Returns the cast result of {@link #getGenericEvent()} to {@link SlashCommandInteractionEvent}.
      *
      * @return The event
      */

--- a/jda/src/main/java/revxrsal/commands/jda/actor/SlashCommandJDAActor.java
+++ b/jda/src/main/java/revxrsal/commands/jda/actor/SlashCommandJDAActor.java
@@ -14,7 +14,7 @@ public interface SlashCommandJDAActor extends JDAActor {
      *
      * @return The actor's message channel union
      */
-    default ReplyCallbackAction deferReply() {
+    default @NotNull ReplyCallbackAction deferReply() {
         return getSlashEvent().deferReply();
     }
 
@@ -23,7 +23,7 @@ public interface SlashCommandJDAActor extends JDAActor {
      *
      * @return The actor's message channel union
      */
-    default MessageChannelUnion getChannelUnion() {
+    default @NotNull MessageChannelUnion getChannelUnion() {
         return getSlashEvent().getChannel();
     }
 

--- a/jda/src/main/java/revxrsal/commands/jda/actor/SlashCommandSuggestionJDAActor.java
+++ b/jda/src/main/java/revxrsal/commands/jda/actor/SlashCommandSuggestionJDAActor.java
@@ -1,0 +1,30 @@
+package revxrsal.commands.jda.actor;
+
+import java.util.List;
+
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.UnmodifiableView;
+
+import net.dv8tion.jda.api.events.interaction.command.CommandAutoCompleteInteractionEvent;
+import net.dv8tion.jda.api.interactions.AutoCompleteQuery;
+import net.dv8tion.jda.api.interactions.commands.OptionMapping;
+import revxrsal.commands.jda.JDAActor;
+
+public interface SlashCommandSuggestionJDAActor extends JDAActor {
+    default @UnmodifiableView @NotNull List<OptionMapping> getOptions(){
+        return getSuggestionEvent().getOptions();
+    }
+
+    default @NotNull AutoCompleteQuery getFocusedOption(){
+        return getSuggestionEvent().getFocusedOption();
+    }
+
+    /**
+     * Returns the cast result of {@link #getGenericEvent()} to {@link CommandAutoCompleteInteractionEvent}.
+     *
+     * @return The event
+     */
+    default @NotNull CommandAutoCompleteInteractionEvent getSuggestionEvent() {
+        return (CommandAutoCompleteInteractionEvent) getGenericEvent();
+    }
+}

--- a/jda/src/main/java/revxrsal/commands/jda/annotation/NSFW.java
+++ b/jda/src/main/java/revxrsal/commands/jda/annotation/NSFW.java
@@ -1,0 +1,19 @@
+package revxrsal.commands.jda.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import revxrsal.commands.annotation.DistributeOnMethods;
+import revxrsal.commands.annotation.NotSender;
+
+/**
+ * Marks a command as NSFW. Used for slash commands.
+ */
+@DistributeOnMethods
+@NotSender.ImpliesNotSender
+@Target({ElementType.METHOD, ElementType.TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface NSFW {
+}

--- a/jda/src/main/java/revxrsal/commands/jda/annotation/OptionChoice.java
+++ b/jda/src/main/java/revxrsal/commands/jda/annotation/OptionChoice.java
@@ -1,0 +1,17 @@
+package revxrsal.commands.jda.annotation;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+import net.dv8tion.jda.api.interactions.commands.OptionType;
+
+/**
+ * Represents choices of {@link OptionType}. If {@link OptionType} is {@code OptionType.NUMBER, OptionType.INTEGER}, it will be automatically 'parsed' using
+ * {@link Double#parseDouble(String)} or {@link Long#parseLong(String)}
+ */
+@Retention(RetentionPolicy.RUNTIME)
+public @interface OptionChoice {
+    String name();
+
+    String value();
+}

--- a/jda/src/main/java/revxrsal/commands/jda/annotation/OptionData.java
+++ b/jda/src/main/java/revxrsal/commands/jda/annotation/OptionData.java
@@ -1,0 +1,32 @@
+package revxrsal.commands.jda.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import net.dv8tion.jda.api.interactions.commands.OptionType;
+import revxrsal.commands.annotation.NotSender;
+
+/**
+ * Define parameter as custom {@link net.dv8tion.jda.api.interactions.commands.build.OptionData} instead of auto resolving.
+ */
+@NotSender.ImpliesNotSender
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface OptionData {
+    OptionType value();
+
+    OptionChoice[] choices() default {};
+
+    String name() default "";
+
+    String description() default "";
+
+    boolean required() default true;
+
+    /**
+     * Defines how {@link #choices()} will be resolved. If {@code true}, it should be proceeded by
+     */
+    boolean autocomplete() default false;
+}

--- a/jda/src/main/java/revxrsal/commands/jda/core/BasicSlashCommandMapper.java
+++ b/jda/src/main/java/revxrsal/commands/jda/core/BasicSlashCommandMapper.java
@@ -1,14 +1,34 @@
 package revxrsal.commands.jda.core;
 
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
 import org.jetbrains.annotations.NotNull;
 
+import net.dv8tion.jda.api.entities.Member;
+import net.dv8tion.jda.api.entities.Role;
+import net.dv8tion.jda.api.entities.User;
+import net.dv8tion.jda.api.entities.channel.concrete.StageChannel;
+import net.dv8tion.jda.api.entities.channel.concrete.TextChannel;
+import net.dv8tion.jda.api.entities.channel.concrete.VoiceChannel;
+import net.dv8tion.jda.api.interactions.commands.Command.Choice;
 import net.dv8tion.jda.api.interactions.commands.DefaultMemberPermissions;
+import net.dv8tion.jda.api.interactions.commands.OptionType;
 import net.dv8tion.jda.api.interactions.commands.build.SlashCommandData;
+import revxrsal.commands.command.CommandParameter;
 import revxrsal.commands.command.ExecutableCommand;
 import revxrsal.commands.jda.SlashCommandMapper;
 import revxrsal.commands.jda.annotation.GuildOnly;
 import revxrsal.commands.jda.annotation.GuildPermission;
+import revxrsal.commands.jda.annotation.NSFW;
+import revxrsal.commands.jda.annotation.OptionChoice;
+import revxrsal.commands.jda.annotation.OptionData;
 import revxrsal.commands.jda.core.adapter.SlashCommandAdapter;
+import revxrsal.commands.util.Primitives;
 
 public class BasicSlashCommandMapper implements SlashCommandMapper {
     @Override
@@ -19,6 +39,78 @@ public class BasicSlashCommandMapper implements SlashCommandMapper {
                 slashCommandData.setGuildOnly(true);
             if (command.hasAnnotation(GuildPermission.class))
                 slashCommandData.setDefaultPermissions(DefaultMemberPermissions.enabledFor(command.getAnnotation(GuildPermission.class).value()));
+            if (command.hasAnnotation(NSFW.class))
+                slashCommandData.setNSFW(true);
         }
+        Map<Integer, CommandParameter> valueParameters = command.getValueParameters();
+        for (int i = 0; i < valueParameters.size(); i++) {
+            CommandParameter parameter = valueParameters.get(i);
+            slashCommandAdapter.addOptions(createOptionData(parameter));
+        }
+    }
+
+    private net.dv8tion.jda.api.interactions.commands.build.OptionData createOptionData(CommandParameter parameter) {
+        String parameterDescription = Optional.ofNullable(parameter.getDescription()).orElse(parameter.getName());
+        if (parameter.hasAnnotation(OptionData.class)) {
+            OptionData optionDataAnnotation = parameter.getAnnotation(OptionData.class);
+            OptionType type = optionDataAnnotation.value();
+            String name = optionDataAnnotation.name().isEmpty() ? parameter.getName() : optionDataAnnotation.name();
+            String description = optionDataAnnotation.description().isEmpty() ? parameterDescription : optionDataAnnotation.description();
+            if (!type.canSupportChoices() && optionDataAnnotation.choices().length != 0) {
+                String choiceSupportedTypes = Arrays.stream(OptionType.values())
+                        .filter(OptionType::canSupportChoices)
+                        .map(OptionType::name)
+                        .collect(Collectors.joining(" "));
+                throw new IllegalArgumentException("Type " + type.name() + " doesn't support choices! Consider using: '" + choiceSupportedTypes + "'");
+            }
+            net.dv8tion.jda.api.interactions.commands.build.OptionData optionData = new net.dv8tion.jda.api.interactions.commands.build.OptionData(type, name,
+                    description, optionDataAnnotation.required(), optionDataAnnotation.autocomplete());
+            if (optionDataAnnotation.choices().length != 0)
+                optionData.addChoices(createChoices(type, optionDataAnnotation.choices()));
+            return optionData;
+        }
+        String name = parameter.getName();
+        boolean required = !parameter.isOptional() && !parameter.isFlag();
+        if (parameter.isSwitch())
+            return new net.dv8tion.jda.api.interactions.commands.build.OptionData(OptionType.BOOLEAN, name, parameterDescription, false);
+        OptionType type = findType(parameter);
+        Collection<Choice> choices = Collections.emptyList();
+        if (Enum.class.isAssignableFrom(parameter.getType())) {
+            Enum<?>[] enums = (Enum<?>[]) parameter.getType().getEnumConstants();
+            choices = Arrays.stream(enums).map(Enum::name).map(enumName -> new Choice(enumName, enumName)).collect(Collectors.toList());
+        }
+        net.dv8tion.jda.api.interactions.commands.build.OptionData optionData = new net.dv8tion.jda.api.interactions.commands.build.OptionData(type, name,
+                parameterDescription, required);
+        if (!choices.isEmpty())
+            optionData.addChoices(choices);
+        return optionData;
+    }
+
+    private OptionType findType(CommandParameter parameter) {
+        Class<?> type = Primitives.wrap(parameter.getType());
+        if (Integer.class.isAssignableFrom(type) || Long.class.isAssignableFrom(type) || Short.class.isAssignableFrom(type) ||
+                Byte.class.isAssignableFrom(type))
+            return OptionType.INTEGER;
+        if (Double.class.isAssignableFrom(type) || Float.class.isAssignableFrom(type))
+            return OptionType.NUMBER;
+        if (Boolean.class.isAssignableFrom(type))
+            return OptionType.BOOLEAN;
+        if (Member.class.isAssignableFrom(type) || User.class.isAssignableFrom(type))
+            return OptionType.USER;
+        if (TextChannel.class.isAssignableFrom(type) || VoiceChannel.class.isAssignableFrom(type) || StageChannel.class.isAssignableFrom(type))
+            return OptionType.CHANNEL;
+        if (Role.class.isAssignableFrom(type))
+            return OptionType.ROLE;
+        return OptionType.STRING;
+    }
+
+    private Collection<Choice> createChoices(OptionType type, OptionChoice[] choices) {
+        return Arrays.stream(choices).map(choiceAnnotation -> {
+            if (type == OptionType.NUMBER)
+                return new Choice(choiceAnnotation.name(), Double.parseDouble(choiceAnnotation.value()));
+            if (type == OptionType.INTEGER)
+                return new Choice(choiceAnnotation.name(), Long.parseLong(choiceAnnotation.value()));
+            return new Choice(choiceAnnotation.name(), choiceAnnotation.value());
+        }).collect(Collectors.toList());
     }
 }

--- a/jda/src/main/java/revxrsal/commands/jda/core/BasicSlashCommandMapper.java
+++ b/jda/src/main/java/revxrsal/commands/jda/core/BasicSlashCommandMapper.java
@@ -70,7 +70,7 @@ public class BasicSlashCommandMapper implements SlashCommandMapper {
             return optionData;
         }
         String name = parameter.getName();
-        boolean required = !parameter.isOptional() && !parameter.isFlag();
+        boolean required = !parameter.isOptional();
         if (parameter.isSwitch())
             return new net.dv8tion.jda.api.interactions.commands.build.OptionData(OptionType.BOOLEAN, name, parameterDescription, false);
         OptionType type = findType(parameter);

--- a/jda/src/main/java/revxrsal/commands/jda/core/BasicSlashCommandMapper.java
+++ b/jda/src/main/java/revxrsal/commands/jda/core/BasicSlashCommandMapper.java
@@ -1,0 +1,24 @@
+package revxrsal.commands.jda.core;
+
+import org.jetbrains.annotations.NotNull;
+
+import net.dv8tion.jda.api.interactions.commands.DefaultMemberPermissions;
+import net.dv8tion.jda.api.interactions.commands.build.SlashCommandData;
+import revxrsal.commands.command.ExecutableCommand;
+import revxrsal.commands.jda.SlashCommandMapper;
+import revxrsal.commands.jda.annotation.GuildOnly;
+import revxrsal.commands.jda.annotation.GuildPermission;
+import revxrsal.commands.jda.core.adapter.SlashCommandAdapter;
+
+public class BasicSlashCommandMapper implements SlashCommandMapper {
+    @Override
+    public void mapSlashCommand(@NotNull SlashCommandAdapter slashCommandAdapter, @NotNull ExecutableCommand command) {
+        if (slashCommandAdapter.isSlashCommand()) {
+            SlashCommandData slashCommandData = slashCommandAdapter.getCommandData();
+            if (command.hasAnnotation(GuildOnly.class))
+                slashCommandData.setGuildOnly(true);
+            if (command.hasAnnotation(GuildPermission.class))
+                slashCommandData.setDefaultPermissions(DefaultMemberPermissions.enabledFor(command.getAnnotation(GuildPermission.class).value()));
+        }
+    }
+}

--- a/jda/src/main/java/revxrsal/commands/jda/core/JDACommandListener.java
+++ b/jda/src/main/java/revxrsal/commands/jda/core/JDACommandListener.java
@@ -145,7 +145,7 @@ final class JDACommandListener implements EventListener {
             Map<Integer, CommandParameter> valueParameters = foundCommand.getValueParameters();
             for (int i = 0; i < valueParameters.size(); i++) {
                 CommandParameter parameter = valueParameters.get(i);
-                OptionMapping optionMapping = event.getOption(parameter.getName());
+                OptionMapping optionMapping = event.getOption(getParameterName(parameter));
                 if (optionMapping == null)
                     continue;
                 if (parameter.isFlag())

--- a/jda/src/main/java/revxrsal/commands/jda/core/JDACommandListener.java
+++ b/jda/src/main/java/revxrsal/commands/jda/core/JDACommandListener.java
@@ -1,34 +1,139 @@
 package revxrsal.commands.jda.core;
 
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import org.jetbrains.annotations.NotNull;
+
 import lombok.AllArgsConstructor;
 import net.dv8tion.jda.api.events.GenericEvent;
+import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent;
 import net.dv8tion.jda.api.events.message.MessageReceivedEvent;
 import net.dv8tion.jda.api.hooks.EventListener;
-import org.jetbrains.annotations.NotNull;
+import net.dv8tion.jda.api.interactions.commands.Command.Type;
+import net.dv8tion.jda.api.interactions.commands.OptionMapping;
+import net.dv8tion.jda.api.interactions.commands.OptionType;
 import revxrsal.commands.command.ArgumentStack;
+import revxrsal.commands.command.CommandCategory;
+import revxrsal.commands.command.CommandParameter;
+import revxrsal.commands.command.ExecutableCommand;
+import revxrsal.commands.core.CommandPath;
 import revxrsal.commands.jda.JDAActor;
 import revxrsal.commands.jda.JDACommandHandler;
+import revxrsal.commands.jda.core.actor.BaseJDAMessageActor;
+import revxrsal.commands.jda.core.actor.BaseJDASlashCommandActor;
 
-@AllArgsConstructor final class JDACommandListener implements EventListener {
-
+@AllArgsConstructor
+final class JDACommandListener implements EventListener {
     private final String prefix;
     private final JDACommandHandler handler;
 
-    @Override public void onEvent(@NotNull GenericEvent genericEvent) {
-        if (!(genericEvent instanceof MessageReceivedEvent)) return;
-        MessageReceivedEvent event = (MessageReceivedEvent) genericEvent;
-        if (event.isWebhookMessage()) return;
-        String content = event.getMessage().getContentRaw();
-        if (!content.startsWith(prefix)) return;
-        content = content.substring(prefix.length());
-        if (content.isEmpty()) return;
+    @Override
+    public void onEvent(@NotNull GenericEvent genericEvent) {
+        if (genericEvent instanceof MessageReceivedEvent)
+            onMessageEvent((MessageReceivedEvent) genericEvent);
+        if (genericEvent instanceof SlashCommandInteractionEvent)
+            onSlashCommandEvent((SlashCommandInteractionEvent) genericEvent);
+    }
 
-        JDAActor actor = new BaseActorJDA(event, handler);
+    private void onSlashCommandEvent(SlashCommandInteractionEvent event) {
+        parseSlashCommandEvent(event).ifPresent(content -> {
+            JDAActor actor = new BaseJDASlashCommandActor(event, handler);
+            try {
+                ArgumentStack arguments = ArgumentStack.parse(content);
+                handler.dispatch(actor, arguments);
+            } catch(Throwable t) {
+                handler.getExceptionHandler().handleException(t, actor);
+            }
+        });
+    }
+
+    private void onMessageEvent(MessageReceivedEvent event) {
+        if (event.isWebhookMessage())
+            return;
+        String content = event.getMessage().getContentRaw();
+        if (!content.startsWith(prefix))
+            return;
+        content = content.substring(prefix.length());
+        if (content.isEmpty())
+            return;
+
+        JDAActor actor = new BaseJDAMessageActor(event, handler);
         try {
             ArgumentStack arguments = ArgumentStack.parse(content);
             handler.dispatch(actor, arguments);
-        } catch (Throwable t) {
+        } catch(Throwable t) {
             handler.getExceptionHandler().handleException(t, actor);
         }
+    }
+
+    /**
+     * Parses a SlashCommandInteractionEvent and converts it to a raw command string.
+     *
+     * @param event The SlashCommandInteractionEvent to parse.
+     * @return An Optional containing the raw command string.
+     */
+    private Optional<String> parseSlashCommandEvent(SlashCommandInteractionEvent event) {
+        if (event.getCommandType() != Type.SLASH)
+            return Optional.of(event.getName());
+        CommandPath commandPath = CommandPath.get(
+                Stream.of(event.getName(), event.getSubcommandGroup(), event.getSubcommandName()).filter(Objects::nonNull).collect(Collectors.toList()));
+
+        ExecutableCommand foundCommand = findExecutableCommand(commandPath);
+        if (foundCommand == null)
+            return Optional.empty();
+        StringBuffer buffer = new StringBuffer();
+        buffer.append(commandPath.toRealString()).append(" ");
+
+        Map<Integer, CommandParameter> valueParameters = foundCommand.getValueParameters();
+        for (int i = 0; i < valueParameters.size(); i++) {
+            CommandParameter parameter = valueParameters.get(i);
+            OptionMapping optionMapping = event.getOption(parameter.getName());
+            if (optionMapping == null)
+                continue;
+            if (parameter.isFlag())
+                buffer.append("-").append(parameter.getFlagName()).append(" ");
+            if (parameter.isSwitch() && optionMapping.getType() == OptionType.BOOLEAN && optionMapping.getAsBoolean()) {
+                buffer.append("-").append(parameter.getSwitchName()).append(" ");
+                continue;
+            }
+            appendOptionMapping(buffer, optionMapping).append(" ");
+        }
+
+        return Optional.of(buffer.toString());
+    }
+
+    private ExecutableCommand findExecutableCommand(CommandPath commandPath) {
+        ExecutableCommand command = handler.getCommand(commandPath);
+        if (command != null)
+            return command;
+
+        CommandCategory category = handler.getCategory(commandPath);
+        if (category == null)
+            return null;
+        return category.getDefaultAction();
+    }
+
+    private StringBuffer appendOptionMapping(StringBuffer buffer, OptionMapping optionMapping) {
+        switch (optionMapping.getType()) {
+            case CHANNEL:
+                buffer.append(optionMapping.getAsChannel().getName());
+                break;
+            case USER:
+                buffer.append(optionMapping.getAsUser().getName());
+                break;
+            case ROLE:
+                buffer.append(optionMapping.getAsRole().getName());
+                break;
+            case MENTIONABLE:
+                buffer.append("<@").append(optionMapping.getAsMentionable().getIdLong()).append(">");
+                break;
+            default:
+                buffer.append(optionMapping.getAsString());
+        }
+        return buffer;
     }
 }

--- a/jda/src/main/java/revxrsal/commands/jda/core/JDAHandler.java
+++ b/jda/src/main/java/revxrsal/commands/jda/core/JDAHandler.java
@@ -65,6 +65,7 @@ public final class JDAHandler extends BaseCommandHandler implements JDACommandHa
         setExceptionHandler(JDAExceptionAdapter.INSTANCE);
         registerPermissionReader(JDAPermission::new);
         registerCondition((actor, command, arguments) -> actor.as(JDAActor.class).checkInGuild(command));
+        registerSlashCommandMapper(new BasicSlashCommandMapper());
         jda.addEventListener(new JDACommandListener(prefix, this));
     }
 

--- a/jda/src/main/java/revxrsal/commands/jda/core/JDAHandler.java
+++ b/jda/src/main/java/revxrsal/commands/jda/core/JDAHandler.java
@@ -1,5 +1,9 @@
 package revxrsal.commands.jda.core;
 
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
 import net.dv8tion.jda.api.EmbedBuilder;
 import net.dv8tion.jda.api.JDA;
 import net.dv8tion.jda.api.entities.*;
@@ -13,10 +17,13 @@ import net.dv8tion.jda.api.events.message.MessageReceivedEvent;
 import net.dv8tion.jda.api.requests.RestAction;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.UnmodifiableView;
+
 import revxrsal.commands.core.BaseCommandHandler;
 import revxrsal.commands.jda.JDAActor;
 import revxrsal.commands.jda.JDACommandHandler;
 import revxrsal.commands.jda.JDAPermission;
+import revxrsal.commands.jda.SlashCommandMapper;
 import revxrsal.commands.jda.exception.JDAExceptionAdapter;
 import revxrsal.commands.process.ContextResolver;
 import revxrsal.commands.process.ValueResolver;
@@ -24,10 +31,11 @@ import revxrsal.commands.process.ValueResolver;
 import static revxrsal.commands.jda.core.SnowflakeResolvers.*;
 import static revxrsal.commands.jda.core.SnowflakeResolvers.UserResolver.USER;
 import static revxrsal.commands.util.Preconditions.notNull;
+import static revxrsal.commands.util.Preconditions.coerceIn;
 
 @ApiStatus.Internal
 public final class JDAHandler extends BaseCommandHandler implements JDACommandHandler {
-
+    private final List<SlashCommandMapper> slashCommandMappers = new ArrayList<>();
     private final JDA jda;
 
     public JDAHandler(@NotNull JDA jda, @NotNull String prefix) {
@@ -56,6 +64,25 @@ public final class JDAHandler extends BaseCommandHandler implements JDACommandHa
         registerPermissionReader(JDAPermission::new);
         registerCondition((actor, command, arguments) -> actor.as(JDAActor.class).checkInGuild(command));
         jda.addEventListener(new JDACommandListener(prefix, this));
+    }
+
+    @Override
+    public @NotNull JDACommandHandler registerSlashCommandMapper(@NotNull SlashCommandMapper commandMapper) {
+        notNull(commandMapper, "slash command mapper");
+        slashCommandMappers.add(commandMapper);
+        return this;
+    }
+
+    @Override
+    public @NotNull JDACommandHandler registerSlashCommandMapper(int priority, @NotNull SlashCommandMapper commandMapper) {
+        notNull(commandMapper, "slash command mapper");
+        slashCommandMappers.add(coerceIn(priority, 0, slashCommandMappers.size()), commandMapper);
+        return this;
+    }
+
+    @Override
+    public @NotNull @UnmodifiableView List<SlashCommandMapper> getSlashCommandMappers() {
+        return Collections.unmodifiableList(slashCommandMappers);
     }
 
     private void registerSnowflakeResolver(Class c, ValueResolver res) {

--- a/jda/src/main/java/revxrsal/commands/jda/core/JDAHandler.java
+++ b/jda/src/main/java/revxrsal/commands/jda/core/JDAHandler.java
@@ -19,6 +19,8 @@ import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.UnmodifiableView;
 
+import revxrsal.commands.annotation.DefaultFor;
+import revxrsal.commands.annotation.Subcommand;
 import revxrsal.commands.core.BaseCommandHandler;
 import revxrsal.commands.jda.JDAActor;
 import revxrsal.commands.jda.JDACommandHandler;
@@ -83,6 +85,37 @@ public final class JDAHandler extends BaseCommandHandler implements JDACommandHa
     @Override
     public @NotNull @UnmodifiableView List<SlashCommandMapper> getSlashCommandMappers() {
         return Collections.unmodifiableList(slashCommandMappers);
+    }
+
+    /**
+     * Registers all existing commands using {@link JDA#updateCommands()}. Currently it have limitations:
+     * <ul>
+     *     <li>Subcommand depth cannot be more than 2, for example: '/foo bar baz bar' will be considered invalid
+     *     <li>We cannot have {@link DefaultFor} for path if it has subcommands annotated with {@link Subcommand}. Command like this will be invalid:
+     *     <pre>
+     *     {@code
+     *     @Command("foo")
+     *     public class FooCommand {
+     *         @DefaultFor("foo")
+     *         public void defaultCommand(CommandActor actor) {
+     *             // Some command logic
+     *         }
+     *
+     *         @Subcommand("bar")
+     *         public void subcommand(CommandActor actor) {
+     *             // Some subcommand logic
+     *         }
+     *     }
+     *     }
+     *     </pre>
+     * </ul>
+     *
+     * @return this {@link JDACommandHandler} instance.
+     */
+    @Override
+    public @NotNull JDACommandHandler registerSlashCommands() {
+        jda.updateCommands().addCommands(SlashCommandConverter.convertCommands(this)).queue();
+        return this;
     }
 
     private void registerSnowflakeResolver(Class c, ValueResolver res) {

--- a/jda/src/main/java/revxrsal/commands/jda/core/SlashCommandConverter.java
+++ b/jda/src/main/java/revxrsal/commands/jda/core/SlashCommandConverter.java
@@ -3,6 +3,7 @@ package revxrsal.commands.jda.core;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
+import java.util.Map.Entry;
 import java.util.Optional;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -106,7 +107,12 @@ public final class SlashCommandConverter {
 
     private static void validateCommandPaths(JDACommandHandler commandHandler) {
         List<CommandPath> commandPaths = Stream.of(commandHandler.getCommands().keySet(),
-                        commandHandler.getCategories().keySet().stream().filter(CommandPath::isRoot).collect(Collectors.toList()))
+                        commandHandler.getCategories()
+                                .entrySet()
+                                .stream()
+                                .filter(entry -> entry.getValue().getParent() == null && entry.getValue().getDefaultAction() != null)
+                                .map(Entry::getKey)
+                                .collect(Collectors.toList()))
                 .flatMap(Collection::stream)
                 .collect(Collectors.toList());
         for (CommandPath path : commandPaths) {

--- a/jda/src/main/java/revxrsal/commands/jda/core/SlashCommandConverter.java
+++ b/jda/src/main/java/revxrsal/commands/jda/core/SlashCommandConverter.java
@@ -1,0 +1,113 @@
+package revxrsal.commands.jda.core;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+import net.dv8tion.jda.api.interactions.commands.build.CommandData;
+import net.dv8tion.jda.api.interactions.commands.build.Commands;
+import net.dv8tion.jda.api.interactions.commands.build.SlashCommandData;
+import net.dv8tion.jda.api.interactions.commands.build.SubcommandData;
+import net.dv8tion.jda.api.interactions.commands.build.SubcommandGroupData;
+import revxrsal.commands.command.CommandCategory;
+import revxrsal.commands.command.ExecutableCommand;
+import revxrsal.commands.jda.JDACommandHandler;
+import revxrsal.commands.jda.core.adapter.SlashCommandAdapter;
+
+/**
+ * A utility class for parsing Lamp's components into JDA's. And JDA component into raw strings.
+ */
+public final class SlashCommandConverter {
+    private SlashCommandConverter() {
+    }
+
+    /**
+     * Parses all the registered commands and categories in the given {@link JDACommandHandler}
+     * and returns converted CommandData collection
+     *
+     * @param commandHandler The {@link JDACommandHandler} instance used to get all commands and categories
+     * @return Converted CommandData collection
+     */
+    public static Collection<? extends CommandData> convertCommands(JDACommandHandler commandHandler) {
+        List<SlashCommandData> commandDataList = new ArrayList<>();
+        List<CommandCategory> roots = commandHandler.getCategories()
+                .values()
+                .stream()
+                .filter(category -> category.getPath().isRoot())
+                .collect(Collectors.toList());
+        List<ExecutableCommand> rootCommands = commandHandler.getCommands()
+                .values()
+                .stream()
+                .filter(command -> command.getPath().isRoot())
+                .collect(Collectors.toList());
+        for (CommandCategory root : roots) {
+            String rootCommandPath = root.getPath().getFirst();
+            commandDataList.add(parseCategory(commandHandler, root, Commands.slash(rootCommandPath, rootCommandPath)));
+        }
+        for (ExecutableCommand root : rootCommands)
+            commandDataList.add(parseCommand(commandHandler, root));
+        return commandDataList;
+    }
+
+    private static SlashCommandData parseCommand(JDACommandHandler commandHandler, ExecutableCommand command) {
+        if (command.getPath().size() > 3)
+            throw new IllegalArgumentException("Command path for JDA slash commands cannot be longer than 3. Path '" + command.getPath().toRealString() + "'");
+
+        String rootCommandPath = command.getPath().getFirst();
+        String commandDescription = Optional.ofNullable(command.getDescription()).orElse(rootCommandPath);
+        if (!command.getPath().isRoot())
+            return null;
+        SlashCommandData commandData = Commands.slash(rootCommandPath, commandDescription);
+        commandHandler.getSlashCommandMappers().forEach(mapper -> mapper.mapSlashCommand(SlashCommandAdapter.of(commandData), command));
+        return commandData;
+    }
+
+    private static void parseSubcommand(JDACommandHandler commandHandler, ExecutableCommand command, SlashCommandData commandData) {
+        if (command.getPath().size() > 3)
+            throw new IllegalArgumentException("Command path for JDA subcommands cannot be longer than 3. Path '" + command.getPath().toRealString() + "'");
+        String subcommandPath = command.getName();
+        String commandDescription = Optional.ofNullable(command.getDescription()).orElse(subcommandPath);
+        SubcommandData subcommandData = new SubcommandData(subcommandPath, commandDescription);
+        commandHandler.getSlashCommandMappers().forEach(mapper -> mapper.mapSlashCommand(SlashCommandAdapter.of(subcommandData), command));
+        if (command.getPath().size() == 2) {
+            commandData.addSubcommands(subcommandData);
+            return;
+        }
+
+        String subcommandGroupPath = command.getParent().getName();
+        SubcommandGroupData subcommandGroup = commandData.getSubcommandGroups()
+                .stream()
+                .filter(group -> group.getName().equals(subcommandGroupPath))
+                .findFirst()
+                .orElseGet(() -> {
+                    SubcommandGroupData group = new SubcommandGroupData(subcommandGroupPath, subcommandGroupPath);
+                    commandData.addSubcommandGroups(group);
+                    return group;
+                });
+        subcommandGroup.addSubcommands(subcommandData);
+    }
+
+    private static SlashCommandData parseCategory(JDACommandHandler commandHandler, CommandCategory category, SlashCommandData parentCommand) {
+        if (category.getDefaultAction() != null) {
+            if (!category.getCategories().isEmpty())
+                throw new IllegalArgumentException("Cannot mix subcommands and base command. Path '" + category.getPath().toRealString() + "'.");
+            if (category.getPath().isRoot())
+                return parseCommand(commandHandler, category.getDefaultAction());
+            parseSubcommand(commandHandler, category.getDefaultAction(), parentCommand);
+        }
+
+        for (CommandCategory children : category.getCategories().values())
+            parseCategory(commandHandler, children, parentCommand);
+
+        for (ExecutableCommand command : category.getCommands().values()) {
+            if (!category.getCategories().isEmpty())
+                throw new IllegalArgumentException(
+                        "Cannot mix subcommand and subcommand categories. Path '" + category.getPath().toRealString() + "'. Command '" +
+                                command.getPath().toRealString() + "'.");
+            parseSubcommand(commandHandler, command, parentCommand);
+        }
+        return parentCommand;
+    }
+}

--- a/jda/src/main/java/revxrsal/commands/jda/core/actor/BaseActorJDA.java
+++ b/jda/src/main/java/revxrsal/commands/jda/core/actor/BaseActorJDA.java
@@ -1,8 +1,8 @@
-package revxrsal.commands.jda.core;
+package revxrsal.commands.jda.core.actor;
 
-import net.dv8tion.jda.api.entities.*;
-import net.dv8tion.jda.api.entities.channel.middleman.MessageChannel;
-import net.dv8tion.jda.api.events.message.MessageReceivedEvent;
+import static revxrsal.commands.jda.core.actor.MemoizingSupplier.memoize;
+
+import net.dv8tion.jda.api.events.Event;
 import org.jetbrains.annotations.NotNull;
 import revxrsal.commands.CommandHandler;
 import revxrsal.commands.command.ExecutableCommand;
@@ -13,18 +13,20 @@ import revxrsal.commands.jda.exception.PrivateMessageOnlyCommandException;
 import java.util.UUID;
 import java.util.function.Supplier;
 
-import static revxrsal.commands.jda.core.MemoizingSupplier.memoize;
-import static revxrsal.commands.util.Preconditions.notNull;
-
-public final class BaseActorJDA implements JDAActor {
+public abstract class BaseActorJDA implements JDAActor {
 
     private final Supplier<UUID> uuid = memoize(() -> new UUID(0, getUser().getIdLong()));
-    private final MessageReceivedEvent event;
+    private final Event event;
     private final CommandHandler handler;
 
-    public BaseActorJDA(MessageReceivedEvent event, CommandHandler handler) {
+    public BaseActorJDA(Event event, CommandHandler handler) {
         this.event = event;
         this.handler = handler;
+    }
+
+    @Override
+    public @NotNull Event getGenericEvent() {
+        return event;
     }
 
     @Override public @NotNull String getName() {
@@ -47,10 +49,6 @@ public final class BaseActorJDA implements JDAActor {
         return handler;
     }
 
-    @Override public @NotNull Member getMember() {
-        return notNull(event.getMember(), "getEvent().getMember()");
-    }
-
     @Override public JDAActor checkInGuild(ExecutableCommand command) {
         if (!isGuildEvent())
             throw new GuildOnlyCommandException(command);
@@ -63,35 +61,11 @@ public final class BaseActorJDA implements JDAActor {
         return this;
     }
 
-    @Override public @NotNull Message getMessage() {
-        return event.getMessage();
-    }
-
-    @Override public @NotNull MessageReceivedEvent getEvent() {
-        return event;
-    }
-
     @Override public long getIdLong() {
         return getUser().getIdLong();
     }
 
     @Override public @NotNull String getId() {
         return getUser().getId();
-    }
-
-    @Override public @NotNull User getUser() {
-        return event.getAuthor();
-    }
-
-    @Override public @NotNull Guild getGuild() {
-        return event.getGuild();
-    }
-
-    @Override public @NotNull MessageChannel getChannel() {
-        return event.getChannel();
-    }
-
-    @Override public boolean isGuildEvent() {
-        return event.isFromGuild();
     }
 }

--- a/jda/src/main/java/revxrsal/commands/jda/core/actor/BaseJDACommandSuggestionActor.java
+++ b/jda/src/main/java/revxrsal/commands/jda/core/actor/BaseJDACommandSuggestionActor.java
@@ -1,0 +1,42 @@
+package revxrsal.commands.jda.core.actor;
+
+import org.jetbrains.annotations.NotNull;
+
+import net.dv8tion.jda.api.entities.Guild;
+import net.dv8tion.jda.api.entities.Member;
+import net.dv8tion.jda.api.entities.User;
+import net.dv8tion.jda.api.entities.channel.middleman.MessageChannel;
+import net.dv8tion.jda.api.events.Event;
+import revxrsal.commands.CommandHandler;
+import revxrsal.commands.jda.actor.SlashCommandSuggestionJDAActor;
+
+public class BaseJDACommandSuggestionActor extends BaseActorJDA implements SlashCommandSuggestionJDAActor {
+    public BaseJDACommandSuggestionActor(Event event, CommandHandler handler) {
+        super(event, handler);
+    }
+
+    @Override
+    public @NotNull User getUser() {
+        return getSuggestionEvent().getUser();
+    }
+
+    @Override
+    public @NotNull MessageChannel getChannel() {
+        return getSuggestionEvent().getChannel();
+    }
+
+    @Override
+    public boolean isGuildEvent() {
+        return getSuggestionEvent().isGuildCommand();
+    }
+
+    @Override
+    public @NotNull Guild getGuild() {
+        return getSuggestionEvent().getGuild();
+    }
+
+    @Override
+    public @NotNull Member getMember() {
+        return getSuggestionEvent().getMember();
+    }
+}

--- a/jda/src/main/java/revxrsal/commands/jda/core/actor/BaseJDAMessageActor.java
+++ b/jda/src/main/java/revxrsal/commands/jda/core/actor/BaseJDAMessageActor.java
@@ -1,0 +1,42 @@
+package revxrsal.commands.jda.core.actor;
+
+import org.jetbrains.annotations.NotNull;
+
+import net.dv8tion.jda.api.entities.Guild;
+import net.dv8tion.jda.api.entities.Member;
+import net.dv8tion.jda.api.entities.User;
+import net.dv8tion.jda.api.entities.channel.middleman.MessageChannel;
+import net.dv8tion.jda.api.events.message.MessageReceivedEvent;
+import revxrsal.commands.CommandHandler;
+import revxrsal.commands.jda.actor.MessageJDAActor;
+
+public class BaseJDAMessageActor extends BaseActorJDA implements MessageJDAActor {
+    public BaseJDAMessageActor(MessageReceivedEvent event, CommandHandler handler) {
+        super(event, handler);
+    }
+
+    @Override
+    public @NotNull User getUser() {
+        return getEvent().getAuthor();
+    }
+
+    @Override
+    public @NotNull MessageChannel getChannel() {
+        return getEvent().getChannel();
+    }
+
+    @Override
+    public boolean isGuildEvent() {
+        return getEvent().isFromGuild();
+    }
+
+    @Override
+    public @NotNull Guild getGuild() {
+        return getEvent().getGuild();
+    }
+
+    @Override
+    public @NotNull Member getMember() {
+        return getEvent().getMember();
+    }
+}

--- a/jda/src/main/java/revxrsal/commands/jda/core/actor/BaseJDASlashCommandActor.java
+++ b/jda/src/main/java/revxrsal/commands/jda/core/actor/BaseJDASlashCommandActor.java
@@ -16,6 +16,16 @@ public class BaseJDASlashCommandActor extends BaseActorJDA implements SlashComma
     }
 
     @Override
+    public void reply(@NotNull String message) {
+        getSlashEvent().reply(getCommandHandler().getMessagePrefix() + message).queue();
+    }
+
+    @Override
+    public void error(@NotNull String message) {
+        getSlashEvent().reply(getCommandHandler().getMessagePrefix() + message).queue();
+    }
+
+    @Override
     public @NotNull User getUser() {
         return getSlashEvent().getUser();
     }

--- a/jda/src/main/java/revxrsal/commands/jda/core/actor/BaseJDASlashCommandActor.java
+++ b/jda/src/main/java/revxrsal/commands/jda/core/actor/BaseJDASlashCommandActor.java
@@ -1,0 +1,42 @@
+package revxrsal.commands.jda.core.actor;
+
+import org.jetbrains.annotations.NotNull;
+
+import net.dv8tion.jda.api.entities.Guild;
+import net.dv8tion.jda.api.entities.Member;
+import net.dv8tion.jda.api.entities.User;
+import net.dv8tion.jda.api.entities.channel.middleman.MessageChannel;
+import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent;
+import revxrsal.commands.CommandHandler;
+import revxrsal.commands.jda.actor.SlashCommandJDAActor;
+
+public class BaseJDASlashCommandActor extends BaseActorJDA implements SlashCommandJDAActor {
+    public BaseJDASlashCommandActor(SlashCommandInteractionEvent event, CommandHandler handler) {
+        super(event, handler);
+    }
+
+    @Override
+    public @NotNull User getUser() {
+        return getSlashEvent().getUser();
+    }
+
+    @Override
+    public @NotNull MessageChannel getChannel() {
+        return getSlashEvent().getChannel();
+    }
+
+    @Override
+    public boolean isGuildEvent() {
+        return getSlashEvent().isFromGuild();
+    }
+
+    @Override
+    public @NotNull Guild getGuild() {
+        return getSlashEvent().getGuild();
+    }
+
+    @Override
+    public @NotNull Member getMember() {
+        return getSlashEvent().getMember();
+    }
+}

--- a/jda/src/main/java/revxrsal/commands/jda/core/actor/MemoizingSupplier.java
+++ b/jda/src/main/java/revxrsal/commands/jda/core/actor/MemoizingSupplier.java
@@ -1,4 +1,4 @@
-package revxrsal.commands.jda.core;
+package revxrsal.commands.jda.core.actor;
 
 import org.jetbrains.annotations.NotNull;
 

--- a/jda/src/main/java/revxrsal/commands/jda/core/adapter/BaseSlashCommandAdapter.java
+++ b/jda/src/main/java/revxrsal/commands/jda/core/adapter/BaseSlashCommandAdapter.java
@@ -1,0 +1,112 @@
+package revxrsal.commands.jda.core.adapter;
+
+import java.util.List;
+import java.util.Map;
+import java.util.function.Predicate;
+
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.UnmodifiableView;
+
+import net.dv8tion.jda.api.interactions.DiscordLocale;
+import net.dv8tion.jda.api.interactions.commands.OptionType;
+import net.dv8tion.jda.api.interactions.commands.build.OptionData;
+import net.dv8tion.jda.api.interactions.commands.build.SlashCommandData;
+import net.dv8tion.jda.api.interactions.commands.localization.LocalizationMap;
+import net.dv8tion.jda.api.utils.data.DataObject;
+
+public class BaseSlashCommandAdapter implements SlashCommandAdapter {
+    private final SlashCommandData slashCommandData;
+
+    public BaseSlashCommandAdapter(@NotNull SlashCommandData slashCommandData) {
+        this.slashCommandData = slashCommandData;
+    }
+
+    @Override
+    public <T> T getCommandData() {
+        return (T) slashCommandData;
+    }
+
+    @Override
+    public @NotNull SlashCommandAdapter setNameLocalization(@NotNull DiscordLocale locale, @NotNull String name) {
+        slashCommandData.setNameLocalization(locale, name);
+        return this;
+    }
+
+    @Override
+    public @NotNull SlashCommandAdapter setDescriptionLocalization(@NotNull DiscordLocale locale, @NotNull String description) {
+        slashCommandData.setDescriptionLocalization(locale, description);
+        return this;
+    }
+
+    @Override
+    public boolean removeOptions(@NotNull Predicate<OptionData> condition) {
+        return slashCommandData.removeOptions(condition);
+    }
+
+    @Override
+    public @NotNull SlashCommandAdapter addOptions(OptionData... options) {
+        slashCommandData.addOptions(options);
+        return this;
+    }
+
+    @Override
+    public @NotNull SlashCommandAdapter addOption(@NotNull OptionType type, @NotNull String name, @NotNull String description, boolean required,
+                                                  boolean autoComplete) {
+        slashCommandData.addOption(type, name, description, required, autoComplete);
+        return this;
+    }
+
+    @Override
+    public @NotNull @UnmodifiableView List<OptionData> getOptions() {
+        return slashCommandData.getOptions();
+    }
+
+    @Override
+    public @NotNull String getName() {
+        return slashCommandData.getName();
+    }
+
+    @Override
+    public @NotNull SlashCommandAdapter setName(@NotNull String name) {
+        slashCommandData.setName(name);
+        return this;
+    }
+
+    @Override
+    public @NotNull LocalizationMap getNameLocalizations() {
+        return slashCommandData.getNameLocalizations();
+    }
+
+    @Override
+    public @NotNull SlashCommandAdapter setNameLocalizations(@NotNull Map<DiscordLocale, String> map) {
+        slashCommandData.setNameLocalizations(map);
+        return this;
+    }
+
+    @Override
+    public @NotNull String getDescription() {
+        return slashCommandData.getDescription();
+    }
+
+    @Override
+    public @NotNull SlashCommandAdapter setDescription(@NotNull String description) {
+        slashCommandData.setDescription(description);
+        return this;
+    }
+
+    @Override
+    public @NotNull LocalizationMap getDescriptionLocalizations() {
+        return slashCommandData.getDescriptionLocalizations();
+    }
+
+    @Override
+    public @NotNull SlashCommandAdapter setDescriptionLocalizations(@NotNull Map<DiscordLocale, String> map) {
+        slashCommandData.setDescriptionLocalizations(map);
+        return this;
+    }
+
+    @Override
+    public @NotNull DataObject toData() {
+        return slashCommandData.toData();
+    }
+}

--- a/jda/src/main/java/revxrsal/commands/jda/core/adapter/BaseSubcommandToSlashAdapter.java
+++ b/jda/src/main/java/revxrsal/commands/jda/core/adapter/BaseSubcommandToSlashAdapter.java
@@ -1,0 +1,112 @@
+package revxrsal.commands.jda.core.adapter;
+
+import java.util.List;
+import java.util.Map;
+import java.util.function.Predicate;
+
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.UnmodifiableView;
+
+import net.dv8tion.jda.api.interactions.DiscordLocale;
+import net.dv8tion.jda.api.interactions.commands.OptionType;
+import net.dv8tion.jda.api.interactions.commands.build.OptionData;
+import net.dv8tion.jda.api.interactions.commands.build.SubcommandData;
+import net.dv8tion.jda.api.interactions.commands.localization.LocalizationMap;
+import net.dv8tion.jda.api.utils.data.DataObject;
+
+public class BaseSubcommandToSlashAdapter implements SlashCommandAdapter {
+    private final SubcommandData subcommandData;
+
+    public BaseSubcommandToSlashAdapter(@NotNull SubcommandData subcommandData) {
+        this.subcommandData = subcommandData;
+    }
+
+    @Override
+    public <T> T getCommandData() {
+        return (T) subcommandData;
+    }
+
+    @Override
+    public @NotNull SlashCommandAdapter setNameLocalization(@NotNull DiscordLocale locale, @NotNull String name) {
+        subcommandData.setNameLocalization(locale, name);
+        return this;
+    }
+
+    @Override
+    public @NotNull SlashCommandAdapter setDescriptionLocalization(@NotNull DiscordLocale locale, @NotNull String description) {
+        subcommandData.setDescriptionLocalization(locale, description);
+        return this;
+    }
+
+    @Override
+    public boolean removeOptions(@NotNull Predicate<OptionData> condition) {
+        return subcommandData.removeOptions(condition);
+    }
+
+    @Override
+    public @NotNull SlashCommandAdapter addOptions(OptionData... options) {
+        subcommandData.addOptions(options);
+        return this;
+    }
+
+    @Override
+    public @NotNull SlashCommandAdapter addOption(@NotNull OptionType type, @NotNull String name, @NotNull String description, boolean required,
+                                                  boolean autoComplete) {
+        subcommandData.addOption(type, name, description, required, autoComplete);
+        return this;
+    }
+
+    @Override
+    public @NotNull @UnmodifiableView List<OptionData> getOptions() {
+        return subcommandData.getOptions();
+    }
+
+    @Override
+    public @NotNull String getName() {
+        return subcommandData.getName();
+    }
+
+    @Override
+    public @NotNull SlashCommandAdapter setName(@NotNull String name) {
+        subcommandData.setName(name);
+        return this;
+    }
+
+    @Override
+    public @NotNull LocalizationMap getNameLocalizations() {
+        return subcommandData.getNameLocalizations();
+    }
+
+    @Override
+    public @NotNull SlashCommandAdapter setNameLocalizations(@NotNull Map<DiscordLocale, String> map) {
+        subcommandData.setNameLocalizations(map);
+        return this;
+    }
+
+    @Override
+    public @NotNull String getDescription() {
+        return subcommandData.getDescription();
+    }
+
+    @Override
+    public @NotNull SlashCommandAdapter setDescription(@NotNull String description) {
+        subcommandData.setDescription(description);
+        return this;
+    }
+
+    @Override
+    public @NotNull LocalizationMap getDescriptionLocalizations() {
+        return subcommandData.getDescriptionLocalizations();
+    }
+
+    @Override
+    public @NotNull SlashCommandAdapter setDescriptionLocalizations(@NotNull Map<DiscordLocale, String> map) {
+        subcommandData.setDescriptionLocalizations(map);
+        return this;
+    }
+
+    @Override
+    public @NotNull DataObject toData() {
+        return subcommandData.toData();
+    }
+}

--- a/jda/src/main/java/revxrsal/commands/jda/core/adapter/SlashCommandAdapter.java
+++ b/jda/src/main/java/revxrsal/commands/jda/core/adapter/SlashCommandAdapter.java
@@ -1,0 +1,88 @@
+package revxrsal.commands.jda.core.adapter;
+
+import static revxrsal.commands.util.Preconditions.notNull;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Predicate;
+
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.UnmodifiableView;
+
+import net.dv8tion.jda.api.interactions.DiscordLocale;
+import net.dv8tion.jda.api.interactions.commands.OptionType;
+import net.dv8tion.jda.api.interactions.commands.build.OptionData;
+import net.dv8tion.jda.api.interactions.commands.build.SlashCommandData;
+import net.dv8tion.jda.api.interactions.commands.build.SubcommandData;
+import net.dv8tion.jda.api.interactions.commands.localization.LocalizationMap;
+import net.dv8tion.jda.api.utils.data.DataObject;
+
+public interface SlashCommandAdapter {
+    @NotNull static SlashCommandAdapter of(@NotNull SlashCommandData slashCommandData) {
+        return new BaseSlashCommandAdapter(slashCommandData);
+    }
+
+    @NotNull static SlashCommandAdapter of(@NotNull SubcommandData subcommandData) {
+        return new BaseSubcommandToSlashAdapter(subcommandData);
+    }
+
+    <T> T getCommandData();
+
+    default boolean isSlashCommand() {
+        Object commandData = getCommandData();
+        return commandData instanceof SlashCommandData;
+    }
+
+    default boolean isSlashSubcommand() {
+        Object commandData = getCommandData();
+        return commandData instanceof SubcommandData;
+    }
+
+    @NotNull SlashCommandAdapter setNameLocalization(@NotNull DiscordLocale locale, @NotNull String name);
+
+    @NotNull SlashCommandAdapter setDescriptionLocalization(@NotNull DiscordLocale locale, @NotNull String description);
+
+    boolean removeOptions(@NotNull Predicate<OptionData> condition);
+
+    default boolean removeOptionByName(@NotNull String name) {
+        return removeOptions(option -> option.getName().equals(name));
+    }
+
+    @NotNull SlashCommandAdapter addOptions(OptionData... options);
+
+    default @NotNull SlashCommandAdapter addOptions(@NotNull Collection<OptionData> options) {
+        notNull(options, "options");
+        return addOptions(options.toArray(new OptionData[0]));
+    }
+
+    @NotNull SlashCommandAdapter addOption(@NotNull OptionType type, @NotNull String name, @NotNull String description, boolean required, boolean autoComplete);
+
+    default SlashCommandAdapter addOption(@NotNull OptionType type, @NotNull String name, @NotNull String description, boolean required) {
+        return addOption(type, name, description, required, false);
+    }
+
+    default SlashCommandAdapter addOption(@NotNull OptionType type, @NotNull String name, @NotNull String description) {
+        return addOption(type, name, description, false);
+    }
+
+    @NotNull @UnmodifiableView List<OptionData> getOptions();
+
+    @NotNull String getName();
+
+    @NotNull SlashCommandAdapter setName(@NotNull String name);
+
+    @NotNull LocalizationMap getNameLocalizations();
+
+    @NotNull SlashCommandAdapter setNameLocalizations(@NotNull Map<DiscordLocale, String> map);
+
+    @NotNull String getDescription();
+
+    @NotNull SlashCommandAdapter setDescription(@NotNull String description);
+
+    @NotNull LocalizationMap getDescriptionLocalizations();
+
+    @NotNull SlashCommandAdapter setDescriptionLocalizations(@NotNull Map<DiscordLocale, String> map);
+
+    @NotNull DataObject toData();
+}

--- a/jda/src/main/java/revxrsal/commands/jda/core/adapter/SlashCommandAdapter.java
+++ b/jda/src/main/java/revxrsal/commands/jda/core/adapter/SlashCommandAdapter.java
@@ -10,78 +10,379 @@ import java.util.function.Predicate;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.UnmodifiableView;
 
+import net.dv8tion.jda.api.events.interaction.command.CommandAutoCompleteInteractionEvent;
 import net.dv8tion.jda.api.interactions.DiscordLocale;
 import net.dv8tion.jda.api.interactions.commands.OptionType;
+import net.dv8tion.jda.api.interactions.commands.build.CommandData;
 import net.dv8tion.jda.api.interactions.commands.build.OptionData;
 import net.dv8tion.jda.api.interactions.commands.build.SlashCommandData;
 import net.dv8tion.jda.api.interactions.commands.build.SubcommandData;
 import net.dv8tion.jda.api.interactions.commands.localization.LocalizationMap;
 import net.dv8tion.jda.api.utils.data.DataObject;
 
+/**
+ * Adapts {@link SlashCommandData} and {@link SubcommandData} into one object.
+ */
 public interface SlashCommandAdapter {
+    /**
+     * Creates a new {@link SlashCommandAdapter} that wraps the given {@link SlashCommandData}
+     *
+     * @param slashCommandData Slash command to wrap
+     * @return The wrapping {@link SlashCommandAdapter} instance
+     */
     @NotNull static SlashCommandAdapter of(@NotNull SlashCommandData slashCommandData) {
         return new BaseSlashCommandAdapter(slashCommandData);
     }
 
+    /**
+     * Creates a new {@link SlashCommandAdapter} that wraps the given {@link SubcommandData}
+     *
+     * @param subcommandData Slash command to wrap
+     * @return The wrapping {@link SlashCommandAdapter} instance
+     */
     @NotNull static SlashCommandAdapter of(@NotNull SubcommandData subcommandData) {
         return new BaseSubcommandToSlashAdapter(subcommandData);
     }
 
+    /**
+     * Returns original {@link SlashCommandData} or {@link SubcommandData}.
+     *
+     * @return Wrapping object instance. May be {@link SlashCommandData}, {@link SubcommandData}
+     * @see #isSlashCommand()
+     * @see #isSlashSubcommand()
+     */
     <T> T getCommandData();
 
+    /**
+     * Returns {@code true} if {@link #getCommandData()} instance of {@link SlashCommandData}
+     *
+     * @return true if wrapping object is {@link SlashCommandData}
+     * @see #getCommandData()
+     */
     default boolean isSlashCommand() {
         Object commandData = getCommandData();
         return commandData instanceof SlashCommandData;
     }
 
+    /**
+     * Returns {@code true} if {@link #getCommandData()} instance of {@link SubcommandData}
+     *
+     * @return true if wrapping object is {@link SubcommandData}
+     * @see #getCommandData()
+     */
     default boolean isSlashSubcommand() {
         Object commandData = getCommandData();
         return commandData instanceof SubcommandData;
     }
 
+    /**
+     * Sets a {@link DiscordLocale language-specific} localization of this {@link #getCommandData()} name.
+     *
+     * @param  locale
+     *         The locale to associate the translated name with
+     *
+     * @param  name
+     *         The translated name to put
+     *
+     * @throws IllegalArgumentException
+     *         <ul>
+     *             <li>If the locale is null</li>
+     *             <li>If the name is null</li>
+     *             <li>If the locale is {@link DiscordLocale#UNKNOWN}</li>
+     *             <li>If the name does not pass the corresponding {@link #setName(String) name check}</li>
+     *         </ul>
+     *
+     * @return This adapter instance, for chaining
+     */
     @NotNull SlashCommandAdapter setNameLocalization(@NotNull DiscordLocale locale, @NotNull String name);
 
+    /**
+     * Sets a {@link DiscordLocale language-specific} localizations of this {@link #getCommandData()} description.
+     *
+     * @param  locale
+     *         The locale to associate the translated description with
+     *
+     * @param  description
+     *         The translated description to put
+     *
+     * @throws IllegalArgumentException
+     *         <ul>
+     *             <li>If the locale is null</li>
+     *             <li>If the description is null</li>
+     *             <li>If the locale is {@link DiscordLocale#UNKNOWN}</li>
+     *             <li>If the description does not pass the corresponding {@link #setDescription(String) description check}</li>
+     *         </ul>
+     *
+     * @return This adapter instance, for chaining
+     */
     @NotNull SlashCommandAdapter setDescriptionLocalization(@NotNull DiscordLocale locale, @NotNull String description);
 
+    /**
+     * Removes all options that evaluate to {@code true} under the provided {@code condition}.
+     * <br>This will not affect options within subcommands.
+     * Use {@link SubcommandData#removeOptions(Predicate)} instead.
+     *
+     * <p><b>Example: Remove all options</b>
+     * <pre>{@code
+     * command.removeOptions(option -> true);
+     * }</pre>
+     * <p><b>Example: Remove all options that are required</b>
+     * <pre>{@code
+     * command.removeOptions(option -> option.isRequired());
+     * }</pre>
+     *
+     * @param  condition
+     *         The removal condition (must not throw)
+     *
+     * @throws IllegalArgumentException
+     *         If the condition is null
+     *
+     * @return True, if any options were removed
+     */
     boolean removeOptions(@NotNull Predicate<OptionData> condition);
 
+    /**
+     * Removes options by the provided name.
+     * <br>This will not affect options within subcommands.
+     * Use {@link SubcommandData#removeOptionByName(String)} instead.
+     *
+     * @param  name
+     *         The <b>case-sensitive</b> option name
+     *
+     * @return True, if any options were removed
+     */
     default boolean removeOptionByName(@NotNull String name) {
         return removeOptions(option -> option.getName().equals(name));
     }
 
+    /**
+     * Adds up to {@value CommandData#MAX_OPTIONS} options to this command.
+     *
+     * <p>Required options must be added before non-required options!
+     *
+     * @param  options
+     *          The {@link OptionData Options} to add
+     *
+     * @throws IllegalArgumentException
+     *         <ul>
+     *             <li>If there already is a subcommand or subcommand group on this command.</li>
+     *             <li>If the option type is {@link OptionType#SUB_COMMAND} or {@link OptionType#SUB_COMMAND_GROUP}.</li>
+     *             <li>If this option is required and you already added a non-required option.</li>
+     *             <li>If more than {@value CommandData#MAX_OPTIONS} options are provided.</li>
+     *             <li>If the option name is not unique</li>
+     *             <li>If null is provided</li>
+     *         </ul>
+     *
+     * @return This adapter instance, for chaining
+     */
     @NotNull SlashCommandAdapter addOptions(OptionData... options);
 
+    /**
+     * Adds up to {@value CommandData#MAX_OPTIONS} options to this {@link #getCommandData()}.
+     *
+     * <p>Required options must be added before non-required options!
+     *
+     * @param  options
+     *         The {@link OptionData Options} to add
+     *
+     * @throws IllegalArgumentException
+     *         <ul>
+     *             <li>If there already is a subcommand or subcommand group on this command.</li>
+     *             <li>If the option type is {@link OptionType#SUB_COMMAND} or {@link OptionType#SUB_COMMAND_GROUP}.</li>
+     *             <li>If this option is required and you already added a non-required option.</li>
+     *             <li>If more than {@value CommandData#MAX_OPTIONS} options are provided.</li>
+     *             <li>If the option name is not unique</li>
+     *             <li>If null is provided</li>
+     *         </ul>
+     *
+     * @return This adapter instance, for chaining
+     */
     default @NotNull SlashCommandAdapter addOptions(@NotNull Collection<OptionData> options) {
         notNull(options, "options");
         return addOptions(options.toArray(new OptionData[0]));
     }
 
+    /**
+     * Adds an option to this {@link #getCommandData()}.
+     *
+     * <p>Required options must be added before non-required options!
+     *
+     * @param  type
+     *         The {@link OptionType}
+     * @param  name
+     *         The lowercase option name, 1-{@value OptionData#MAX_NAME_LENGTH} characters
+     * @param  description
+     *         The option description, 1-{@value OptionData#MAX_DESCRIPTION_LENGTH} characters
+     * @param  required
+     *         Whether this option is required (See {@link OptionData#setRequired(boolean)})
+     * @param  autoComplete
+     *         Whether this option supports auto-complete via {@link CommandAutoCompleteInteractionEvent},
+     *         only supported for option types which {@link OptionType#canSupportChoices() support choices}
+     *
+     * @throws IllegalArgumentException
+     *         <ul>
+     *             <li>If there already is a subcommand or subcommand group on this command.</li>
+     *             <li>If the option type is {@link OptionType#UNKNOWN UNKNOWN}.</li>
+     *             <li>If the option type is {@link OptionType#SUB_COMMAND} or {@link OptionType#SUB_COMMAND_GROUP}.</li>
+     *             <li>If the provided option type does not support auto-complete</li>
+     *             <li>If this option is required and you already added a non-required option.</li>
+     *             <li>If more than {@value CommandData#MAX_OPTIONS} options are provided.</li>
+     *             <li>If the option name is not unique</li>
+     *             <li>If null is provided</li>
+     *         </ul>
+     *
+     * @return This adapter instance, for chaining
+     */
     @NotNull SlashCommandAdapter addOption(@NotNull OptionType type, @NotNull String name, @NotNull String description, boolean required, boolean autoComplete);
 
-    default SlashCommandAdapter addOption(@NotNull OptionType type, @NotNull String name, @NotNull String description, boolean required) {
+    /**
+     * Adds an option to this {@link #getCommandData()}.
+     *
+     * <p>Required options must be added before non-required options!
+     *
+     * @param  type
+     *         The {@link OptionType}
+     * @param  name
+     *         The lowercase option name, 1-{@value OptionData#MAX_NAME_LENGTH} characters
+     * @param  description
+     *         The option description, 1-{@value OptionData#MAX_DESCRIPTION_LENGTH} characters
+     * @param  required
+     *         Whether this option is required (See {@link OptionData#setRequired(boolean)})
+     *
+     * @throws IllegalArgumentException
+     *         <ul>
+     *             <li>If this option is required and you already added a non-required option.</li>
+     *             <li>If more than {@value CommandData#MAX_OPTIONS} options are provided.</li>
+     *             <li>If the option name is not unique</li>
+     *             <li>If null is provided</li>
+     *         </ul>
+     *
+     * @return This adapter instance, for chaining
+     */
+    default @NotNull SlashCommandAdapter addOption(@NotNull OptionType type, @NotNull String name, @NotNull String description, boolean required) {
         return addOption(type, name, description, required, false);
     }
 
-    default SlashCommandAdapter addOption(@NotNull OptionType type, @NotNull String name, @NotNull String description) {
+    /**
+     * Adds an option to this {@link #getCommandData()}.
+     * <br>The option is set to be non-required! You can use {@link #addOption(OptionType, String, String, boolean)} to add a required option instead.
+     *
+     * <p>Required options must be added before non-required options!
+     *
+     * @param  type
+     *         The {@link OptionType}
+     * @param  name
+     *         The lowercase option name, 1-{@value OptionData#MAX_NAME_LENGTH} characters
+     * @param  description
+     *         The option description, 1-{@value OptionData#MAX_DESCRIPTION_LENGTH} characters
+     *
+     * @throws IllegalArgumentException
+     *         <ul>
+     *             <li>If this option is required and you already added a non-required option.</li>
+     *             <li>If more than {@value CommandData#MAX_OPTIONS} options are provided.</li>
+     *             <li>If the option name is not unique</li>
+     *             <li>If null is provided</li>
+     *         </ul>
+     *
+     * @return This adapter instance, for chaining
+     */
+    default @NotNull SlashCommandAdapter addOption(@NotNull OptionType type, @NotNull String name, @NotNull String description) {
         return addOption(type, name, description, false);
     }
 
+    /**
+     * The options for this command.
+     *
+     * @return Immutable list of {@link OptionData}
+     */
     @NotNull @UnmodifiableView List<OptionData> getOptions();
 
+    /**
+     * The configured name
+     *
+     * @return The name
+     */
     @NotNull String getName();
 
+    /**
+     * Configure the name
+     *
+     * @param  name
+     *         The lowercase alphanumeric (with dash) name, 1-32 characters
+     *
+     * @throws IllegalArgumentException
+     *         If the name is null, not alphanumeric, or not between 1-32 characters
+     *
+     * @return This adapter instance, for chaining
+     */
     @NotNull SlashCommandAdapter setName(@NotNull String name);
 
+    /**
+     * The localizations of this subcommand's name for {@link DiscordLocale various languages}.
+     *
+     * @return The {@link LocalizationMap} containing the mapping from {@link DiscordLocale} to the localized name
+     */
     @NotNull LocalizationMap getNameLocalizations();
 
+    /**
+     * Sets multiple {@link DiscordLocale language-specific} localizations of this {@link #getCommandData()} name.
+     *
+     * @param  map
+     *         The map from which to transfer the translated names
+     *
+     * @throws IllegalArgumentException
+     *         <ul>
+     *             <li>If the map is null</li>
+     *             <li>If the map contains an {@link DiscordLocale#UNKNOWN} key</li>
+     *             <li>If the map contains a name which does not pass the corresponding {@link #setName(String) name check}</li>
+     *         </ul>
+     *
+     * @return This adapter instance, for chaining
+     */
     @NotNull SlashCommandAdapter setNameLocalizations(@NotNull Map<DiscordLocale, String> map);
 
+    /**
+     * The configured description
+     *
+     * @return The description
+     */
     @NotNull String getDescription();
 
+    /**
+     * Configure the description
+     *
+     * @param  description
+     *         The description, 1-100 characters
+     *
+     * @throws IllegalArgumentException
+     *         If the name is null or not between 1-100 characters
+     *
+     * @return This adapter instance, for chaining
+     */
     @NotNull SlashCommandAdapter setDescription(@NotNull String description);
 
+    /**
+     * The localizations of this {@link #getCommandData()} description for {@link DiscordLocale various languages}.
+     *
+     * @return The {@link LocalizationMap} containing the mapping from {@link DiscordLocale} to the localized description
+     */
     @NotNull LocalizationMap getDescriptionLocalizations();
 
+    /**
+     * Sets multiple {@link DiscordLocale language-specific} localizations of this {@link #getCommandData()} description.
+     *
+     * @param  map
+     *         The map from which to transfer the translated descriptions
+     *
+     * @throws IllegalArgumentException
+     *         <ul>
+     *             <li>If the map is null</li>
+     *             <li>If the map contains an {@link DiscordLocale#UNKNOWN} key</li>
+     *             <li>If the map contains a description which does not pass the corresponding {@link #setDescription(String) description check}</li>
+     *         </ul>
+     *
+     * @return This adapter instance, for chaining
+     */
     @NotNull SlashCommandAdapter setDescriptionLocalizations(@NotNull Map<DiscordLocale, String> map);
 
     @NotNull DataObject toData();

--- a/jda/src/main/java/revxrsal/commands/jda/exception/InvalidCategoryException.java
+++ b/jda/src/main/java/revxrsal/commands/jda/exception/InvalidCategoryException.java
@@ -1,10 +1,8 @@
 package revxrsal.commands.jda.exception;
 
 import org.jetbrains.annotations.NotNull;
-import revxrsal.commands.command.CommandActor;
 import revxrsal.commands.command.CommandParameter;
 import revxrsal.commands.exception.InvalidValueException;
-import revxrsal.commands.jda.JDAActor;
 
 public class InvalidCategoryException extends InvalidValueException {
 


### PR DESCRIPTION
### What is this change supposed to do?
This change adds support of JDA slash commands. And solved several problems with Lamp and Discord slash commands compatibility. Also this change should be backward compatible. 
This pull request adds:
1. Registering commands as slash commands in discord. (With handling conflicts).
2. `SuggestionProvider` will also handle JDA event `CommandAutoCompleteInteractionEvent`
3. Flexible ways to define parameters in slash commands. Manually describe parameter using `@OptionData` annotation, otherwise Lamp will handle automatically.

### Backward compatibility
1. I've changed JDAActor by deprecating several methods: `getMessage()`, `getEvent()`. 
2. I didn't removed any value resolver, context resolver, or something like that. 
3. I've added `getGenericEvent()` method. Also i've created `actor` package in root directory (`/src/main/java/revxrsal/commands/jda/actor`) where we define `MessageJDAActor`, `SlashCommandJDAActor` that represents actors of specific events. But i didn't move `JDAActor`

So I think there shouldn't be any problem for migrating to new slash command support. Also i've mentioned alternative methods for Deprecated methods

### How to use?

**Register slash commands:**
```java
public class SomeCommandRegistry {
    private static final String TOKEN = "randomDiscordToken";
    private final JDACommandHandler commandHandler = JDACommandHandler.create(JDABuilder.createDefault(TOKEN).build(), "");
    
    public void registerCommands() {
        commandHandler.register(new PermissionCommand());
        commandHandler.register(new RoleCommand());
        // Register all existing commands as slash commands in jda
        commandHandler.registerSlashCommands();
    }
}
```

---

**Manually describe parameter**
```java
@Command("parametertest")
public class TestCommand {
    @DefaultFor("parametertest")
    public void test(CommandActor actor,
                     @OptionData(value = OptionType.STRING, name = "animal", description = "What animal you want to test?", choices = {@OptionChoice(name =
                             "dog", value = "DOG"), @OptionChoice(name = "cat", value = "CAT")}) String animal) {
        actor.reply("You have chosen " + animal);
    }
}
```
Screenshots:
![animal_manual_autocomplete_example](https://github.com/Revxrsal/Lamp/assets/85439143/1832b79a-28ac-4e64-afd9-da00259d130f)
![animal_manual_execution_example](https://github.com/Revxrsal/Lamp/assets/85439143/66f5ee4c-5ce8-44f7-b832-9a37989e2ee1)

---

If we don't want to manually write parameter, we can do like this:
**Automatic parameter description**
```java
    @DefaultFor("parametertest")
    public void test(CommandActor actor, @Named("animal") Animal animal) {
        actor.reply("You have chosen " + animal);
    }

    public enum Animal {
        DOG, CAT
    }
```
Screenshots:
![animal_auto_autocomplete_example](https://github.com/Revxrsal/Lamp/assets/85439143/7697c107-2f4c-471f-bc1a-dccbf28278e0)
![animal_manual_execution_example](https://github.com/Revxrsal/Lamp/assets/85439143/c2d3ddf2-634b-491d-8f97-2f8e53583f15)

****

---

Also we can use other parameters too, we can define complex commands like this:
```java
    @DefaultFor("complextest")
    @Description("Some complex command :).")
    public void fooCommand(CommandActor actor, @Named("firstinteger") int integer, @Named("secondnumber") double number, @Named("text") String text,
                           @Named("animal") TestEnum animal, @Flag("flagvalue") String flagValue, @Switch("toggle") boolean toggle) {
        actor.reply("Integer is " + integer + ", number is " + number + " text is " + text + " and animal " + animal + ". Flag " + flagValue + ", toggled: " +
                toggle);
    }
```

Screenshots:
Autocomplete:
![autocomplete_complex_example](https://github.com/Revxrsal/Lamp/assets/85439143/ecc49261-8e70-46fe-b804-b80b69f2654c)

Proper typing:
![integer_type_example](https://github.com/Revxrsal/Lamp/assets/85439143/7116d39b-a165-4dea-907a-c70bf90af7a8)

When we execute command:
![full_input_example](https://github.com/Revxrsal/Lamp/assets/85439143/c4ebe891-c113-4684-b1a8-68c372777255)

Switch parameter:
![switch_parameter_example](https://github.com/Revxrsal/Lamp/assets/85439143/f9635d82-2fe5-416e-a05f-001bbc23a316)
![switch_parameter_execution](https://github.com/Revxrsal/Lamp/assets/85439143/80505d4a-fe63-42f5-b79c-8fa01b4d527c)


Note: We can remove `@Named` annotation, but it will result naming our parameters: arg0, arg1, arg2...

## Limitations

If we read [documentation of discord slash commands](https://discord.com/developers/docs/interactions/application-commands#subcommands-and-subcommand-groups), we can see that we cannot define long chain of subcommands, cannot have base command and subcommand at the same time according to:
![base_subcommand_conflict](https://github.com/Revxrsal/Lamp/assets/85439143/89807610-ee0f-41a4-9634-7f0e3a36146b) 

Note: Every edge case was handled in `/core/SlashCommandConverter`.

And we can see how this pull request handles such edge cases:
```java
@Command("permission")
public class PermissionCommand {
    @DefaultFor("permission")
    public void baseCommandAction() {
        // Do something in base command action
    }
    
    @Subcommand("add")
    public void permissionAdd(){
        // Add permission
    }
    
    @Subcommand("remove")
    public void permissionRemove(){
        // Remove permission
    }
}
```
**Expected exception**
```java
Exception in thread "main" java.lang.IllegalArgumentException: Paths `permission add` and `permission` are conflicting, remove or modify one of paths
	at revxrsal.commands.jda.core.SlashCommandConverter.validateCommandPaths(SlashCommandConverter.java:117)
	at revxrsal.commands.jda.core.SlashCommandConverter.convertCommands(SlashCommandConverter.java:36)
	at revxrsal.commands.jda.core.JDAHandler.registerSlashCommands(JDAHandler.java:118)
```
This is considered invalid because `permission` have at the same time subcommand (`add` and `remove`), and command implementation (`@DefaultFor("permission")`)

---

Another similar limitation
```java
@Command("permission")
public class PermissionCommand {
    @Subcommand("add")
    public void permissionAdd(){
        // Add permission
    }

    @Subcommand("add hide")
    public void permissionAddHidden() {
        // Add hidden permission
    }

    @Subcommand("remove")
    public void permissionRemove() {
        // Remove permission
    }
}
```
**Expected exception:**
```java
Exception in thread "main" java.lang.IllegalArgumentException: Paths `permission add hide` and `permission add` are conflicting, remove or modify one of paths
	at revxrsal.commands.jda.core.SlashCommandConverter.validateCommandPaths(SlashCommandConverter.java:117)
	at revxrsal.commands.jda.core.SlashCommandConverter.convertCommands(SlashCommandConverter.java:36)
	at revxrsal.commands.jda.core.JDAHandler.registerSlashCommands(JDAHandler.java:118)
```
Where we have two paths `permission add` and `permission add hide`. Where `permission add` is base path, and `permission add hide` is subcommand of base path. And base path have 'implementation' and 'subcommand' at the same time, which doesn't allowed.

---

Another problem is, we cannot have too deep subcommands. For example it is impossible create such command path in discord:
`/permission firstsubcommand secondsubcommand thirdsubcommand`
Because we can only create subcommand groups, and subcommands.

---

Related issue: https://github.com/Revxrsal/Lamp/issues/50

---

If you have any questions, feel free to ask :)