### PR TITLE
Properly handle DefaultFor in JDA Slash commands

### DIFF
--- a/jda/src/main/java/revxrsal/commands/jda/core/SlashCommandConverter.java
+++ b/jda/src/main/java/revxrsal/commands/jda/core/SlashCommandConverter.java
@@ -71,6 +71,8 @@ public final class SlashCommandConverter {
     private static void parseSubcommand(JDACommandHandler commandHandler, ExecutableCommand command, SlashCommandData commandData) {
         if (command.getPath().size() > 3)
             throw new IllegalArgumentException("Command path for JDA subcommands cannot be longer than 3. Path '" + command.getPath().toRealString() + "'");
+        if (command.getPath().size() <= 1)
+            return;
         String subcommandPath = command.getName();
         String commandDescription = Optional.ofNullable(command.getDescription()).orElse(subcommandPath);
         SubcommandData subcommandData = new SubcommandData(subcommandPath, commandDescription);

--- a/jda/src/main/java/revxrsal/commands/jda/core/SlashCommandConverter.java
+++ b/jda/src/main/java/revxrsal/commands/jda/core/SlashCommandConverter.java
@@ -47,8 +47,13 @@ public final class SlashCommandConverter {
                 .filter(command -> command.getPath().isRoot())
                 .collect(Collectors.toList());
         for (CommandCategory root : roots) {
-            String rootCommandPath = root.getPath().getFirst();
-            commandDataList.add(parseCategory(commandHandler, root, Commands.slash(rootCommandPath, rootCommandPath)));
+            CommandPath rootPath = root.getPath();
+            if (rootPath.size() == 1 && root.getDefaultAction() != null) {
+                commandDataList.add(parseCommand(commandHandler, root.getDefaultAction()));
+                continue;
+            }
+            String commandPath = root.getPath().getFirst();
+            commandDataList.add(parseCategory(commandHandler, root, Commands.slash(commandPath, commandPath)));
         }
         for (ExecutableCommand root : rootCommands)
             commandDataList.add(parseCommand(commandHandler, root));


### PR DESCRIPTION
Fixed 
```java
@Command("simple")
public class SimpleCommand {
  @DefaultFor("simple")
  public void defaultCommand(CommandActor actor) {
      actor.reply("Works");
  }
}
```

Where previous version would register: `/simple simple simple` instead of `/simple`