### PR TITLE
Add support of '@Default' and '@Optional' to JDA Slash commands

### DIFF
--- a/jda/src/main/java/revxrsal/commands/jda/core/JDACommandListener.java
+++ b/jda/src/main/java/revxrsal/commands/jda/core/JDACommandListener.java
@@ -131,10 +131,10 @@ final class JDACommandListener implements EventListener {
     }
 
     /**
-     * Parses a SlashCommandInteractionEvent and converts event to a raw command string.
+     * Parses a SlashCommandInteractionEvent and converts event to an {@link ArgumentStack}.
      *
      * @param event The SlashCommandInteractionEvent to parse.
-     * @return An Optional containing the raw command string.
+     * @return An Optional containing the {@link ArgumentStack}.
      */
     private Optional<ArgumentStack> parseSlashCommandEvent(SlashCommandInteractionEvent event) {
         if (event.getCommandType() != Type.SLASH)

--- a/jda/src/main/java/revxrsal/commands/jda/core/JDACommandListener.java
+++ b/jda/src/main/java/revxrsal/commands/jda/core/JDACommandListener.java
@@ -146,8 +146,10 @@ final class JDACommandListener implements EventListener {
             for (int i = 0; i < valueParameters.size(); i++) {
                 CommandParameter parameter = valueParameters.get(i);
                 OptionMapping optionMapping = event.getOption(getParameterName(parameter));
-                if (optionMapping == null)
+                if (optionMapping == null) {
+                    arguments.addAll(parameter.getDefaultValue());
                     continue;
+                }
                 if (parameter.isFlag())
                     arguments.add("-" + parameter.getFlagName());
                 if (parameter.isSwitch() && optionMapping.getType() == OptionType.BOOLEAN && optionMapping.getAsBoolean()) {

--- a/jda/src/main/java/revxrsal/commands/jda/core/SlashCommandConverter.java
+++ b/jda/src/main/java/revxrsal/commands/jda/core/SlashCommandConverter.java
@@ -47,8 +47,13 @@ public final class SlashCommandConverter {
                 .filter(command -> command.getPath().isRoot())
                 .collect(Collectors.toList());
         for (CommandCategory root : roots) {
-            String rootCommandPath = root.getPath().getFirst();
-            commandDataList.add(parseCategory(commandHandler, root, Commands.slash(rootCommandPath, rootCommandPath)));
+            CommandPath rootPath = root.getPath();
+            if (rootPath.size() == 1 && root.getDefaultAction() != null) {
+                commandDataList.add(parseCommand(commandHandler, root.getDefaultAction()));
+                continue;
+            }
+            String commandPath = root.getPath().getFirst();
+            commandDataList.add(parseCategory(commandHandler, root, Commands.slash(commandPath, commandPath)));
         }
         for (ExecutableCommand root : rootCommands)
             commandDataList.add(parseCommand(commandHandler, root));


### PR DESCRIPTION
**What this Pull Request changes**
1. Instead of returning raw `String` in `JDACommandListener#parseSlashCommandEvent`, now we are returning `ArgumentStack`. This may be useful for future, if we could somehow put 'null' values into `ArgumentStack`, and because of that, we could easily handle some `@Optional` edge cases. I've written about some edge cases below.
2. Support `@Default` and `@Optional` properly

---

**Results**
I've wrote test class for `@Optional` and `@Default`, and provided some screenshots below:
```java
@Command("optional")
public class OptionalAndDefaultTest {
    @Subcommand("first")
    public void firstTest(CommandActor actor, @Optional @Named("opt") Integer optional) {
        actor.reply("Optional argument is " + optional + ", is null: " + (optional == null));
    }

    @Subcommand("second")
    public void secondTest(CommandActor actor, @Default("-1") @Named("def") Integer defaultValue) {
        actor.reply("Default argument is " + defaultValue);
    }

    @Subcommand("third")
    public void thirdTest(CommandActor actor, @Default("-1") @Named("def") Integer defaultValue, @Optional @Named("opt") Integer optionalValue) {
        actor.reply("Default argument is " + defaultValue + ". Optional argument is " + optionalValue + ", is null: " + (optionalValue == null));
    }
```
### `firstTest`:
![firstTest-autocomplete](https://github.com/Revxrsal/Lamp/assets/85439143/729cfbe6-9931-49cf-b6be-0ada5e701376)
![firstTest-first-execute](https://github.com/Revxrsal/Lamp/assets/85439143/dc5de69e-6a8e-4148-8657-49758ef38651)
![firstTest-second-execute](https://github.com/Revxrsal/Lamp/assets/85439143/983ae904-d18e-4c15-b54b-94074da8d9ea)

### `secondTest`:
![secondTest-autocomplete](https://github.com/Revxrsal/Lamp/assets/85439143/e8e45b74-c410-4664-95aa-6591c817efcb)
![secondTest-first-execute](https://github.com/Revxrsal/Lamp/assets/85439143/e9230945-0327-4989-a158-a1afc20008f7)
![secondTest-second-execute](https://github.com/Revxrsal/Lamp/assets/85439143/edfb6368-8c83-4d0c-8a83-af34cc52b308)


### `thirdTest`:
![thirdTest-autocomplete](https://github.com/Revxrsal/Lamp/assets/85439143/ade39c1c-2959-4e3d-bd65-3be4286ee519)
![thirdTest-first-execute](https://github.com/Revxrsal/Lamp/assets/85439143/2d19dd73-8c53-4e6e-9d0d-8de2ab3330e5)
![thirdTest-second-execute](https://github.com/Revxrsal/Lamp/assets/85439143/c50e950e-0cc6-462f-9300-a5a4ab27a750)
![thirdTest-third-execute](https://github.com/Revxrsal/Lamp/assets/85439143/23c8ba19-aed1-47b2-8753-c90a1ead361c)
![thirdTest-fourth-execute](https://github.com/Revxrsal/Lamp/assets/85439143/185efedf-578a-4ec4-9373-9dc172c56210)



---

**Edge cases**
Only edge case i could found is:
```java

@Subcommand("fourth")
public void fourthTest(CommandActor actor, @Optional Integer optionalValue, @Default("-1") Integer defaultValue) {
    actor.reply("Default argument is " + defaultValue + ". Optional argument is " + optionalValue + ", is null: " + (optionalValue == null));
}
```
Where we should place `@Optional` **before** `@Default`.

**Note**: We can't place `@Optional` **before** non-null values, because this is **restricted** by Discord. So we can't have such edge cases.

Have a nice day! 