### PR TITLE
fix: support OfflinePlayer resolver for freshly-joined players

### DIFF
--- a/bukkit/src/main/java/revxrsal/commands/bukkit/core/BukkitHandler.java
+++ b/bukkit/src/main/java/revxrsal/commands/bukkit/core/BukkitHandler.java
@@ -101,7 +101,7 @@ public final class BukkitHandler extends BaseCommandHandler implements BukkitCom
             if (value.equalsIgnoreCase("self") || value.equalsIgnoreCase("me"))
                 return ((BukkitCommandActor) context.actor()).requirePlayer();
             OfflinePlayer player = Bukkit.getOfflinePlayer(value);
-            if (!player.hasPlayedBefore() && !player.isOnline())
+            if (player.getFirstPlayed() == 0L)
                 throw new InvalidPlayerException(context.parameter(), value);
             return player;
         });


### PR DESCRIPTION
currently, if the referenced player is online but has only *just* joined the server (their first known session), the resolver will fail and throw an InvalidPlayerException, despite the player being online.

to combat this, we can use the "first played" timestamp to check if the player has ever existed on the server.