### PR TITLE
[Feature] Custom message types in Locale/Translator

### DIFF
--- a/common/src/main/java/revxrsal/commands/command/CommandActor.java
+++ b/common/src/main/java/revxrsal/commands/command/CommandActor.java
@@ -28,7 +28,6 @@ import org.jetbrains.annotations.Nullable;
 import revxrsal.commands.CommandHandler;
 import revxrsal.commands.locales.Translator;
 
-import java.text.MessageFormat;
 import java.util.Locale;
 import java.util.Optional;
 import java.util.UUID;
@@ -117,8 +116,7 @@ public interface CommandActor {
      * @param args The arguments to format with
      */
     default void replyLocalized(@NotNull String key, Object... args) {
-        String message = MessageFormat.format(getTranslator().get(key, getLocale()), args);
-        reply(message);
+        getTranslator().reply(this, key, getLocale(), args);
     }
 
     /**
@@ -128,8 +126,7 @@ public interface CommandActor {
      * @param args The arguments to format with
      */
     default void errorLocalized(@NotNull String key, Object... args) {
-        String message = MessageFormat.format(getTranslator().get(key, getLocale()), args);
-        error(message);
+        getTranslator().error(this, key, getLocale(), args);
     }
 
     /**

--- a/common/src/main/java/revxrsal/commands/locales/DynamicLocaleReader.java
+++ b/common/src/main/java/revxrsal/commands/locales/DynamicLocaleReader.java
@@ -1,0 +1,48 @@
+package revxrsal.commands.locales;
+
+import revxrsal.commands.command.CommandActor;
+
+import java.util.Locale;
+
+/**
+ * A locale reader is a source in which custom typed messages for a specific locale
+ * are fetched. This can be a file, a resource bundle, or even a remote
+ * source.
+ */
+public interface DynamicLocaleReader<T> extends LocaleMessageTransmitter<T> {
+
+    /**
+     * Returns whether this reader contains a mapping for the
+     * given key.
+     *
+     * @param key Key to check for
+     * @return {@code true} if this reader has a mapping for the key
+     */
+    boolean containsKey(String key);
+
+    /**
+     * Returns the mapping value for this key. It is recommended that
+     * this only return values if {@link #containsKey(String)} is true,
+     * otherwise throwing an exception to avoid confusion.
+     *
+     * @param key Key to fetch for
+     * @return The string value
+     */
+
+    T get(String key);
+
+    /**
+     * Returns the locale of by this reader
+     *
+     * @return The reader's locale
+     */
+    Locale getLocale();
+
+    default void reply(CommandActor actor, String key, Object... args) {
+        reply(actor, format(get(key), args));
+    }
+
+    default void error(CommandActor actor, String key, Object... args) {
+        error(actor, format(get(key), args));
+    }
+}

--- a/common/src/main/java/revxrsal/commands/locales/LocaleMessageTransmitter.java
+++ b/common/src/main/java/revxrsal/commands/locales/LocaleMessageTransmitter.java
@@ -1,0 +1,13 @@
+package revxrsal.commands.locales;
+
+import revxrsal.commands.command.CommandActor;
+
+public interface LocaleMessageTransmitter<T> {
+    void reply(CommandActor actor, T message);
+
+    default void error(CommandActor actor, T message) {
+        reply(actor, message);
+    }
+
+    T format(T message, Object... args);
+}

--- a/common/src/main/java/revxrsal/commands/locales/LocaleReader.java
+++ b/common/src/main/java/revxrsal/commands/locales/LocaleReader.java
@@ -24,42 +24,29 @@
 package revxrsal.commands.locales;
 
 import org.jetbrains.annotations.NotNull;
+import revxrsal.commands.command.CommandActor;
 
-import java.util.Locale;
+import java.text.MessageFormat;
 import java.util.ResourceBundle;
 
 /**
- * A locale reader is a source in which messages for a specific locale
+ * A locale reader is a source in which plain messages for a specific locale
  * are fetched. This can be a file, a resource bundle, or even a remote
  * source.
  */
-public interface LocaleReader {
+public interface LocaleReader extends DynamicLocaleReader<String> {
 
-    /**
-     * Returns whether this reader contains a mapping for the
-     * given key.
-     *
-     * @param key Key to check for
-     * @return {@code true} if this reader has a mapping for the key
-     */
-    boolean containsKey(String key);
+    @Override default void reply(CommandActor actor, String message) {
+        actor.reply(message);
+    }
 
-    /**
-     * Returns the mapping value for this key. It is recommended that
-     * this only return values if {@link #containsKey(String)} is true,
-     * otherwise throwing an exception to avoid confusion.
-     *
-     * @param key Key to fetch for
-     * @return The string value
-     */
-    String get(String key);
+    @Override default void error(CommandActor actor, String message) {
+        actor.error(message);
+    }
 
-    /**
-     * Returns the locale of by this reader
-     *
-     * @return The reader's locale
-     */
-    Locale getLocale();
+    @Override default String format(String message, Object... args) {
+        return MessageFormat.format(message, args);
+    }
 
     /**
      * Wraps a {@link ResourceBundle} in a {@link LocaleReader}.

--- a/common/src/main/java/revxrsal/commands/locales/Translator.java
+++ b/common/src/main/java/revxrsal/commands/locales/Translator.java
@@ -24,6 +24,7 @@
 package revxrsal.commands.locales;
 
 import org.jetbrains.annotations.NotNull;
+import revxrsal.commands.command.CommandActor;
 
 import java.util.Locale;
 import java.util.ResourceBundle;
@@ -42,6 +43,10 @@ public interface Translator {
     static @NotNull Translator create() {
         return new SimpleTranslator();
     }
+
+    void reply(@NotNull CommandActor actor, @NotNull String key, @NotNull Locale locale, @NotNull Object... args);
+
+    void error(@NotNull CommandActor actor, @NotNull String key, @NotNull Locale locale, @NotNull Object... args);
 
     /**
      * Returns the message that corresponds to the given key, using
@@ -65,11 +70,11 @@ public interface Translator {
     @NotNull String get(@NotNull String key, @NotNull Locale locale);
 
     /**
-     * Adds the given locale reader to this translator.
+     * Adds the given dynamic locale reader to this translator.
      *
      * @param reader The locale reader to add
      */
-    void add(@NotNull LocaleReader reader);
+    void add(@NotNull DynamicLocaleReader<?> reader);
 
     /**
      * Registers the given resource bundle


### PR DESCRIPTION
## Pull Request Etiquette

<!--
  There are several guidelines you should follow in order for your
  Pull Request to be merged.
-->

- [x] I have checked the PRs for upcoming features/bug fixes.

<!--
  It is sometimes better to include more changes in a single commit. 
  If you find yourself having an overwhelming amount of commits, you
  can **rebase** your branch.
-->

### Changes

- [X] Internal code
- [X] API (affecting end-user code)
- [ ] Other: _

<!-- Replace "NaN" with an issue number if this is a response to an issue -->

Closes Issue: #75 

## Description

This pull request makes possible to create custom locale reader types that can send adventure component, discord embed messages, and etc. 

### Breaking changes:
I believe that this Pull Request doesn't have any breaking changes. Please let me know if you have found one.  

### How to use:
Simply implement `DynamicLocaleReader` instead of `LocaleReader`, and register using `Translator#add`. childrenList
Example:
ComponentLocaleReader:
```java
public final class ComponentLocaleReader implements DynamicLocaleReader<Component> {

    private static final String ANSI_RED = "\u001B[31m";
    private static final String ANSI_GREEN = "\u001B[32m";
    private final Map<String, Component> components;

    public ComponentLocaleReader(Map<String, Component> components) {
        this.components = components;
    }

    @Override
    public boolean containsKey(String s) {
        return components.containsKey(s);
    }

    @Override
    public Component get(String s) {
        return components.get(s);
    }

    @Override
    public Locale getLocale() {
        return Locale.ENGLISH;
    }

    @Override
    public void reply(CommandActor actor, Component message) {
        // We could cast CommandActor instead, but this is only for example.
        actor.reply(ANSI_GREEN + message.raw());
    }

    @Override
    public void error(CommandActor actor, Component message) {
        // We could cast CommandActor instead, but this is only for example.
        actor.error(ANSI_RED + message.raw());
    }

    @Override
    public Component format(Component component, Object... objects) {
        for (int i = 0; i < objects.length; i += 2)
            component.replace(objects[i].toString(), objects[i + 1].toString());
        return component;
    }

}
```
---
Component:
```java
public final class Component {

    private String component;

    public Component(String component) {
        this.component = component;
    }

    public void replace(String pattern, String replacement) {
        component = component.replace(pattern, replacement);
    }

    public String raw() {
        return component;
    }

}
```

### Current state
Currently this Pull Request was tested using `ConsoleCommandHandler`.