### PR TITLE
Allow to change the translator of a CommandHandler

### DIFF
--- a/common/src/main/java/revxrsal/commands/CommandHandler.java
+++ b/common/src/main/java/revxrsal/commands/CommandHandler.java
@@ -87,6 +87,11 @@ public interface CommandHandler {
     @NotNull Translator getTranslator();
 
     /**
+     * Sets the translator of this command handler
+     */
+    void setTranslator(@NotNull Translator translator);
+
+    /**
      * Sets the {@link MethodCallerFactory} responsible for generating access
      * to reflection methods.
      * <p>

--- a/common/src/main/java/revxrsal/commands/CommandHandler.java
+++ b/common/src/main/java/revxrsal/commands/CommandHandler.java
@@ -88,6 +88,8 @@ public interface CommandHandler {
 
     /**
      * Sets the translator of this command handler
+     *
+     * @param translator the translator of this command handler
      */
     void setTranslator(@NotNull Translator translator);
 

--- a/common/src/main/java/revxrsal/commands/core/BaseCommandHandler.java
+++ b/common/src/main/java/revxrsal/commands/core/BaseCommandHandler.java
@@ -102,7 +102,7 @@ public abstract class BaseCommandHandler implements CommandHandler {
     ParameterNamingStrategy parameterNamingStrategy = ParameterNamingStrategy.lowerCaseWithSpace();
     boolean failOnExtra = false;
     final List<CommandCondition> conditions = new ArrayList<>();
-    private final Translator translator = Translator.create();
+    private Translator translator = Translator.create();
 
     @SuppressWarnings("rawtypes")
     public BaseCommandHandler() {
@@ -209,6 +209,12 @@ public abstract class BaseCommandHandler implements CommandHandler {
 
     @Override public @NotNull Translator getTranslator() {
         return translator;
+    }
+
+    @Override public void setTranslator(@NotNull Translator translator) {
+        Locale previous = getLocale();
+        this.translator = translator;
+        this.translator.setLocale(previous);
     }
 
     private void findPermission(@Nullable CommandExecutable executable) {

--- a/common/src/main/java/revxrsal/commands/core/BaseCommandHandler.java
+++ b/common/src/main/java/revxrsal/commands/core/BaseCommandHandler.java
@@ -212,9 +212,9 @@ public abstract class BaseCommandHandler implements CommandHandler {
     }
 
     @Override public void setTranslator(@NotNull Translator translator) {
-        Locale previous = getLocale();
+        Locale locale = getLocale();
         this.translator = translator;
-        this.translator.setLocale(previous);
+        this.translator.setLocale(locale);
     }
 
     private void findPermission(@Nullable CommandExecutable executable) {


### PR DESCRIPTION
The `LocaleReader` system is quite limiting when you already have a localization system.
So allow to change the translator, so one can redirect it to said existing system while still preserving Lamp API.