### PR TITLE
Migrate to Java 8

### DIFF
--- a/brigadier/src/main/java/revxrsal/commands/brigadier/BNode.java
+++ b/brigadier/src/main/java/revxrsal/commands/brigadier/BNode.java
@@ -43,6 +43,15 @@ final class BNode<S> {
         this.node = node;
     }
 
+    public static <S> @NotNull BNode<S> of(@NotNull CommandNode<S> node) {
+        notNull(node, "node");
+        return new BNode<>(node);
+    }
+
+    public static <S> @NotNull BNode<S> literal(@NotNull String name) {
+        return of(LiteralArgumentBuilder.<S>literal(name).build());
+    }
+
     public @NotNull BNode<S> executes(Command<S> command) {
         Nodes.setCommand(node, command);
         return this;
@@ -54,8 +63,10 @@ final class BNode<S> {
     }
 
     public @NotNull BNode<S> suggests(SuggestionProvider<S> suggestionProvider) {
-        if (node instanceof ArgumentCommandNode<S, ?> argument)
+        if (node instanceof ArgumentCommandNode) {
+            ArgumentCommandNode<S, ?> argument = (ArgumentCommandNode<S, ?>) node;
             Nodes.setSuggestionProvider(argument, suggestionProvider);
+        }
         return this;
     }
 
@@ -72,15 +83,6 @@ final class BNode<S> {
     @Contract(pure = true)
     public @NotNull CommandNode<S> asBrigadierNode() {
         return node;
-    }
-
-    public static <S> @NotNull BNode<S> of(@NotNull CommandNode<S> node) {
-        notNull(node, "node");
-        return new BNode<>(node);
-    }
-
-    public static <S> @NotNull BNode<S> literal(@NotNull String name) {
-        return of(LiteralArgumentBuilder.<S>literal(name).build());
     }
 
     @NotNull BNode<S> nextChild() {

--- a/brigadier/src/main/java/revxrsal/commands/brigadier/BrigadierParser.java
+++ b/brigadier/src/main/java/revxrsal/commands/brigadier/BrigadierParser.java
@@ -73,7 +73,8 @@ public final class BrigadierParser<S, A extends CommandActor> {
             BNode<S> elementNode;
             if (node.isLiteral()) {
                 elementNode = BNode.literal(node.name());
-            } else if (node instanceof ParameterNode<A, ?> parameter) {
+            } else if (node instanceof ParameterNode) {
+                ParameterNode<A, ?> parameter = (ParameterNode<A, ?>) node;
                 if (parameter.isSwitch() || parameter.isFlag())
                     break;
                 elementNode = BNode.of(ofParameter(parameter));

--- a/brigadier/src/main/java/revxrsal/commands/brigadier/types/ArgumentTypes.java
+++ b/brigadier/src/main/java/revxrsal/commands/brigadier/types/ArgumentTypes.java
@@ -31,9 +31,7 @@ import revxrsal.commands.autocomplete.SuggestionProviders;
 import revxrsal.commands.command.CommandActor;
 import revxrsal.commands.node.ParameterNode;
 
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.List;
+import java.util.*;
 
 import static revxrsal.commands.util.Preconditions.notNull;
 
@@ -50,7 +48,7 @@ public final class ArgumentTypes<A extends CommandActor> {
      * <p>
      * These also will not be included in {@link #toBuilder()}.
      */
-    private static final List<ArgumentTypeFactory<?>> HIGHEST_PRIORITY = List.of(
+    private static final List<ArgumentTypeFactory<?>> HIGHEST_PRIORITY = Collections.singletonList(
             BTypeFactory.INSTANCE
     );
 
@@ -60,7 +58,7 @@ public final class ArgumentTypes<A extends CommandActor> {
      * <p>
      * These also will not be included in {@link #toBuilder()}.
      */
-    private static final List<ArgumentTypeFactory<?>> DEFAULT_FACTORIES = List.of(
+    private static final List<ArgumentTypeFactory<?>> DEFAULT_FACTORIES = Arrays.asList(
             DefaultTypeFactories.LONG,
             DefaultTypeFactories.INTEGER,
             DefaultTypeFactories.SHORT,

--- a/brigadier/src/main/java/revxrsal/commands/brigadier/types/BTypeFactory.java
+++ b/brigadier/src/main/java/revxrsal/commands/brigadier/types/BTypeFactory.java
@@ -39,17 +39,19 @@ enum BTypeFactory implements ArgumentTypeFactory<CommandActor> {
     INSTANCE;
 
     @Override
-    @SuppressWarnings("unchecked")
+    @SuppressWarnings({"unchecked", "rawtypes"})
     public @Nullable ArgumentType<?> getArgumentType(@NotNull ParameterNode<CommandActor, ?> parameter) {
         BType b = parameter.annotations().get(BType.class);
         if (b == null)
             return null;
         Object v = InstanceCreator.create(b.value());
-        if (v instanceof ArgumentTypeFactory<?> factory)
-            //noinspection rawtypes
+        if (v instanceof ArgumentTypeFactory<?>) {
+            ArgumentTypeFactory<?> factory = (ArgumentTypeFactory<?>) v;
             return factory.getArgumentType(((ParameterNode) parameter));
-        if (v instanceof ArgumentType<?> type)
-            return type;
+        }
+        if (v instanceof ArgumentType<?>) {
+            return (ArgumentType<?>) v;
+        }
         throw new IllegalArgumentException("Don't know how to create an ArgumentType from @BType(" + b.value().getName() + ".class)");
     }
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -20,7 +20,7 @@ version = "4.0.0-beta.16"
 
 java {
     toolchain {
-        languageVersion.set(JavaLanguageVersion.of(17))
+        languageVersion.set(JavaLanguageVersion.of(8))
     }
 }
 
@@ -39,7 +39,7 @@ subprojects {
 
     java {
         toolchain {
-            languageVersion.set(JavaLanguageVersion.of(17))
+            languageVersion.set(JavaLanguageVersion.of(8))
         }
     }
 

--- a/bukkit/build.gradle.kts
+++ b/bukkit/build.gradle.kts
@@ -16,12 +16,12 @@ dependencies {
         exclude(module = "spigot-api")
         exclude(module = "brigadier")
     }
+    compileOnly("com.destroystokyo.paper:paper-api:1.13.2-R0.1-SNAPSHOT") {
+        exclude(module = "spigot-api")
+        exclude(module = "adventure")
+    }
     compileOnly("org.spigotmc:spigot-api:1.16.5-R0.1-SNAPSHOT")
     compileOnly("com.mojang:brigadier:1.0.18")
-    compileOnly("io.papermc.paper:paper-mojangapi:1.19.1-R0.1-SNAPSHOT")
-    compileOnly("io.papermc.paper:paper-api:1.19.1-R0.1-SNAPSHOT")
 
     compileOnly("net.kyori:adventure-platform-bukkit:4.3.4")
 }
-
-java.toolchain.languageVersion.set(JavaLanguageVersion.of(17))

--- a/bukkit/src/main/java/revxrsal/commands/bukkit/BukkitVisitors.java
+++ b/bukkit/src/main/java/revxrsal/commands/bukkit/BukkitVisitors.java
@@ -281,7 +281,7 @@ public final class BukkitVisitors {
             @NotNull ActorFactory<A> actorFactory
     ) {
         if (BukkitVersion.supportsAsyncCompletion()) {
-            return new LampBuilderVisitor<>() {
+            return new LampBuilderVisitor<A>() {
                 private boolean registered = false;
 
                 @Override public void visit(Lamp.@NotNull Builder<A> builder) {

--- a/bukkit/src/main/java/revxrsal/commands/bukkit/actor/BasicBukkitActor.java
+++ b/bukkit/src/main/java/revxrsal/commands/bukkit/actor/BasicBukkitActor.java
@@ -11,18 +11,32 @@ import revxrsal.commands.Lamp;
 import revxrsal.commands.process.MessageSender;
 
 import java.nio.charset.StandardCharsets;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.UUID;
 
-record BasicBukkitActor(
-        CommandSender sender,
-        Plugin plugin,
-        Optional<BukkitAudiences> audiences,
-        MessageSender<BukkitCommandActor, ComponentLike> messageSender,
-        Lamp<BukkitCommandActor> lamp
-) implements BukkitCommandActor {
+final class BasicBukkitActor implements BukkitCommandActor {
 
     private static final UUID CONSOLE_UUID = new UUID(0, 0);
+    private final CommandSender sender;
+    private final Plugin plugin;
+    private final Optional<BukkitAudiences> audiences;
+    private final MessageSender<BukkitCommandActor, ComponentLike> messageSender;
+    private final Lamp<BukkitCommandActor> lamp;
+
+    BasicBukkitActor(
+            CommandSender sender,
+            Plugin plugin,
+            Optional<BukkitAudiences> audiences,
+            MessageSender<BukkitCommandActor, ComponentLike> messageSender,
+            Lamp<BukkitCommandActor> lamp
+    ) {
+        this.sender = sender;
+        this.plugin = plugin;
+        this.audiences = audiences;
+        this.messageSender = messageSender;
+        this.lamp = lamp;
+    }
 
     @Override public @NotNull CommandSender sender() {
         return sender;
@@ -38,8 +52,8 @@ record BasicBukkitActor(
     @Override public @NotNull Optional<Audience> audience() {
         //noinspection DataFlowIssue
         if (sender instanceof Audience)
-            return Optional.of(sender);
-        if (audiences.isEmpty())
+            return Optional.of((Audience) sender);
+        if (!audiences.isPresent())
             return Optional.empty();
         BukkitAudiences bukkitAudiences = audiences.get();
         return Optional.of(bukkitAudiences.sender(sender()));
@@ -57,4 +71,38 @@ record BasicBukkitActor(
     @Override public Lamp<BukkitCommandActor> lamp() {
         return lamp;
     }
+
+    public Plugin plugin() {return plugin;}
+
+    public Optional<BukkitAudiences> audiences() {return audiences;}
+
+    public MessageSender<BukkitCommandActor, ComponentLike> messageSender() {return messageSender;}
+
+    @Override
+    public boolean equals(Object obj) {
+        if (obj == this) return true;
+        if (obj == null || obj.getClass() != this.getClass()) return false;
+        BasicBukkitActor that = (BasicBukkitActor) obj;
+        return Objects.equals(this.sender, that.sender) &&
+                Objects.equals(this.plugin, that.plugin) &&
+                Objects.equals(this.audiences, that.audiences) &&
+                Objects.equals(this.messageSender, that.messageSender) &&
+                Objects.equals(this.lamp, that.lamp);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(sender, plugin, audiences, messageSender, lamp);
+    }
+
+    @Override
+    public String toString() {
+        return "BasicBukkitActor[" +
+                "sender=" + sender + ", " +
+                "plugin=" + plugin + ", " +
+                "audiences=" + audiences + ", " +
+                "messageSender=" + messageSender + ", " +
+                "lamp=" + lamp + ']';
+    }
+
 }

--- a/bukkit/src/main/java/revxrsal/commands/bukkit/brigadier/ByPaperEvents.java
+++ b/bukkit/src/main/java/revxrsal/commands/bukkit/brigadier/ByPaperEvents.java
@@ -143,9 +143,10 @@ final class ByPaperEvents<A extends BukkitCommandActor> implements BukkitBrigadi
         @EventHandler
         @SuppressWarnings("deprecation")
         public void onCommandRegistered(CommandRegisteredEvent<?> event) {
-            if (!(event.getCommand() instanceof PluginCommand pCommand)) {
+            if (!(event.getCommand() instanceof PluginCommand)) {
                 return;
             }
+            PluginCommand pCommand = (PluginCommand) event.getCommand();
             if (!(pCommand.getExecutor() instanceof LampCommandExecutor<?>)) {
                 return;
             }

--- a/bukkit/src/main/java/revxrsal/commands/bukkit/exception/BukkitExceptionHandler.java
+++ b/bukkit/src/main/java/revxrsal/commands/bukkit/exception/BukkitExceptionHandler.java
@@ -59,11 +59,15 @@ public class BukkitExceptionHandler extends DefaultExceptionHandler<BukkitComman
 
     @Override public void onInputParse(@NotNull InputParseException e, @NotNull BukkitCommandActor actor) {
         switch (e.cause()) {
-            case INVALID_ESCAPE_CHARACTER ->
-                    actor.error(legacyColorize("&cInvalid input. Use &e\\\\ &cto include a backslash."));
-            case UNCLOSED_QUOTE -> actor.error(legacyColorize("&cUnclosed quote. Make sure to close all quotes."));
-            case EXPECTED_WHITESPACE ->
-                    actor.error(legacyColorize("&cExpected whitespace to end one argument, but found trailing data."));
+            case INVALID_ESCAPE_CHARACTER:
+                actor.error(legacyColorize("&cInvalid input. Use &e\\\\ &cto include a backslash."));
+                break;
+            case UNCLOSED_QUOTE:
+                actor.error(legacyColorize("&cUnclosed quote. Make sure to close all quotes."));
+                break;
+            case EXPECTED_WHITESPACE:
+                actor.error(legacyColorize("&cExpected whitespace to end one argument, but found trailing data."));
+                break;
         }
     }
 

--- a/bukkit/src/main/java/revxrsal/commands/bukkit/parameters/PlayerParameterType.java
+++ b/bukkit/src/main/java/revxrsal/commands/bukkit/parameters/PlayerParameterType.java
@@ -63,8 +63,9 @@ public final class PlayerParameterType implements ParameterType<BukkitCommandAct
             if (entityList.size() != 1)
                 throw new MoreThanOneEntityException(selector);
             Entity entity = entityList.get(0);
-            if (!(entity instanceof Player player))
+            if (!(entity instanceof Player))
                 throw new NonPlayerEntitiesException(selector);
+            Player player = (Player) entity;
             return player;
         } catch (IllegalArgumentException e) {
             throw new MalformedEntitySelectorException(selector, e.getCause().getMessage());

--- a/bukkit/src/main/java/revxrsal/commands/bukkit/sender/BukkitCommandPermission.java
+++ b/bukkit/src/main/java/revxrsal/commands/bukkit/sender/BukkitCommandPermission.java
@@ -5,12 +5,42 @@ import org.jetbrains.annotations.NotNull;
 import revxrsal.commands.bukkit.actor.BukkitCommandActor;
 import revxrsal.commands.command.CommandPermission;
 
+import java.util.Objects;
+
 /**
  * A Bukkit-adapted wrapper for {@link CommandPermission}
  */
-public record BukkitCommandPermission(@NotNull Permission permission) implements CommandPermission<BukkitCommandActor> {
+public final class BukkitCommandPermission implements CommandPermission<BukkitCommandActor> {
+    private final @NotNull Permission permission;
+
+    /**
+     *
+     */
+    public BukkitCommandPermission(@NotNull Permission permission) {this.permission = permission;}
 
     @Override public boolean isExecutableBy(@NotNull BukkitCommandActor actor) {
         return actor.sender().hasPermission(permission);
     }
+
+    public @NotNull Permission permission() {return permission;}
+
+    @Override
+    public boolean equals(Object obj) {
+        if (obj == this) return true;
+        if (obj == null || obj.getClass() != this.getClass()) return false;
+        BukkitCommandPermission that = (BukkitCommandPermission) obj;
+        return Objects.equals(this.permission, that.permission);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(permission);
+    }
+
+    @Override
+    public String toString() {
+        return "BukkitCommandPermission[" +
+                "permission=" + permission + ']';
+    }
+
 }

--- a/bukkit/src/main/java/revxrsal/commands/bukkit/util/BukkitVersion.java
+++ b/bukkit/src/main/java/revxrsal/commands/bukkit/util/BukkitVersion.java
@@ -25,10 +25,12 @@ public final class BukkitVersion {
      * The current version string, for example 1_17_R1
      */
     private static final String VERSION = fetchVersion();
+
     /**
      * The version where NMS no longer uses versions in the package names
      */
     private static final int UNVERSION_NMS = 17;
+
     /**
      * The CraftBukkit package
      */

--- a/bungee/build.gradle.kts
+++ b/bungee/build.gradle.kts
@@ -11,5 +11,3 @@ dependencies {
     implementation(project(":common"))
     compileOnly("net.md-5:bungeecord-api:1.16-R0.4")
 }
-
-java.toolchain.languageVersion.set(JavaLanguageVersion.of(17))

--- a/bungee/src/main/java/revxrsal/commands/bungee/actor/BasicBungeeActor.java
+++ b/bungee/src/main/java/revxrsal/commands/bungee/actor/BasicBungeeActor.java
@@ -6,9 +6,17 @@ import org.jetbrains.annotations.NotNull;
 import revxrsal.commands.Lamp;
 
 import java.nio.charset.StandardCharsets;
+import java.util.Objects;
 import java.util.UUID;
 
-record BasicBungeeActor(CommandSender sender, Lamp<BungeeCommandActor> lamp) implements BungeeCommandActor {
+final class BasicBungeeActor implements BungeeCommandActor {
+    private final CommandSender sender;
+    private final Lamp<BungeeCommandActor> lamp;
+
+    BasicBungeeActor(CommandSender sender, Lamp<BungeeCommandActor> lamp) {
+        this.sender = sender;
+        this.lamp = lamp;
+    }
 
     @Override public @NotNull CommandSender sender() {
         return sender;
@@ -24,4 +32,26 @@ record BasicBungeeActor(CommandSender sender, Lamp<BungeeCommandActor> lamp) imp
     @Override public Lamp<BungeeCommandActor> lamp() {
         return lamp;
     }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (obj == this) return true;
+        if (obj == null || obj.getClass() != this.getClass()) return false;
+        BasicBungeeActor that = (BasicBungeeActor) obj;
+        return Objects.equals(this.sender, that.sender) &&
+                Objects.equals(this.lamp, that.lamp);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(sender, lamp);
+    }
+
+    @Override
+    public String toString() {
+        return "BasicBungeeActor[" +
+                "sender=" + sender + ", " +
+                "lamp=" + lamp + ']';
+    }
+
 }

--- a/bungee/src/main/java/revxrsal/commands/bungee/exception/BungeeExceptionHandler.java
+++ b/bungee/src/main/java/revxrsal/commands/bungee/exception/BungeeExceptionHandler.java
@@ -29,11 +29,15 @@ public class BungeeExceptionHandler extends DefaultExceptionHandler<BungeeComman
 
     @Override public void onInputParse(@NotNull InputParseException e, @NotNull BungeeCommandActor actor) {
         switch (e.cause()) {
-            case INVALID_ESCAPE_CHARACTER ->
-                    actor.error(legacyColorize("&cInvalid input. Use &e\\\\ &cto include a backslash."));
-            case UNCLOSED_QUOTE -> actor.error(legacyColorize("&cUnclosed quote. Make sure to close all quotes."));
-            case EXPECTED_WHITESPACE ->
-                    actor.error(legacyColorize("&cExpected whitespace to end one argument, but found trailing data."));
+            case INVALID_ESCAPE_CHARACTER:
+                actor.error(legacyColorize("&cInvalid input. Use &e\\\\ &cto include a backslash."));
+                break;
+            case UNCLOSED_QUOTE:
+                actor.error(legacyColorize("&cUnclosed quote. Make sure to close all quotes."));
+                break;
+            case EXPECTED_WHITESPACE:
+                actor.error(legacyColorize("&cExpected whitespace to end one argument, but found trailing data."));
+                break;
         }
     }
 

--- a/cli/src/main/java/revxrsal/commands/cli/actor/CommandLineActor.java
+++ b/cli/src/main/java/revxrsal/commands/cli/actor/CommandLineActor.java
@@ -6,18 +6,32 @@ import revxrsal.commands.cli.ConsoleActor;
 
 import java.io.InputStream;
 import java.io.PrintStream;
+import java.util.Objects;
 import java.util.Scanner;
 import java.util.UUID;
 
-record CommandLineActor(
-        Lamp<ConsoleActor> lamp,
-        InputStream inputStream,
-        PrintStream outputStream,
-        PrintStream errorStream,
-        Scanner scanner
-) implements ConsoleActor {
+final class CommandLineActor implements ConsoleActor {
 
     private static final UUID CLI_UUID = new UUID(0, 0);
+    private final Lamp<ConsoleActor> lamp;
+    private final InputStream inputStream;
+    private final PrintStream outputStream;
+    private final PrintStream errorStream;
+    private final Scanner scanner;
+
+    CommandLineActor(
+            Lamp<ConsoleActor> lamp,
+            InputStream inputStream,
+            PrintStream outputStream,
+            PrintStream errorStream,
+            Scanner scanner
+    ) {
+        this.lamp = lamp;
+        this.inputStream = inputStream;
+        this.outputStream = outputStream;
+        this.errorStream = errorStream;
+        this.scanner = scanner;
+    }
 
     @Override public @NotNull String name() {
         return "Command Line";
@@ -34,4 +48,42 @@ record CommandLineActor(
     @Override public void sendRawError(@NotNull String message) {
         errorStream.println(message);
     }
+
+    @Override public Lamp<ConsoleActor> lamp() {return lamp;}
+
+    @Override public InputStream inputStream() {return inputStream;}
+
+    @Override public PrintStream outputStream() {return outputStream;}
+
+    @Override public PrintStream errorStream() {return errorStream;}
+
+    @Override public Scanner scanner() {return scanner;}
+
+    @Override
+    public boolean equals(Object obj) {
+        if (obj == this) return true;
+        if (obj == null || obj.getClass() != this.getClass()) return false;
+        CommandLineActor that = (CommandLineActor) obj;
+        return Objects.equals(this.lamp, that.lamp) &&
+                Objects.equals(this.inputStream, that.inputStream) &&
+                Objects.equals(this.outputStream, that.outputStream) &&
+                Objects.equals(this.errorStream, that.errorStream) &&
+                Objects.equals(this.scanner, that.scanner);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(lamp, inputStream, outputStream, errorStream, scanner);
+    }
+
+    @Override
+    public String toString() {
+        return "CommandLineActor[" +
+                "lamp=" + lamp + ", " +
+                "inputStream=" + inputStream + ", " +
+                "outputStream=" + outputStream + ", " +
+                "errorStream=" + errorStream + ", " +
+                "scanner=" + scanner + ']';
+    }
+
 }

--- a/common/build.gradle.kts
+++ b/common/build.gradle.kts
@@ -13,7 +13,3 @@ tasks {
         useJUnitPlatform()
     }
 }
-
-kotlin {
-    jvmToolchain(17)
-}

--- a/common/src/main/java/revxrsal/commands/Lamp.java
+++ b/common/src/main/java/revxrsal/commands/Lamp.java
@@ -65,6 +65,8 @@ import java.util.function.Supplier;
 
 import static revxrsal.commands.util.Classes.checkRetention;
 import static revxrsal.commands.util.Classes.wrap;
+import static revxrsal.commands.util.Collections.copyList;
+import static revxrsal.commands.util.Collections.copyMap;
 import static revxrsal.commands.util.Preconditions.notNull;
 
 /**
@@ -95,14 +97,16 @@ public final class Lamp<A extends CommandActor> {
     private final BaseCommandRegistry<A> tree;
     private final AutoCompleter<A> autoCompleter;
 
+    @SuppressWarnings("unchecked")
     public Lamp(Builder<A> builder) {
-        this.annotationReplacers = Map.copyOf(builder.annotationReplacers);
-        this.senderResolvers = List.copyOf(builder.senderResolvers);
-        this.validators = List.copyOf(builder.validators);
-        this.responseHandlers = List.copyOf(builder.responseHandlers);
-        this.commandConditions = List.copyOf(builder.conditions);
-        this.permissionFactories = List.copyOf(builder.permissionFactories);
-        this.dependencies = Map.copyOf(builder.dependencies);
+        this.annotationReplacers = copyMap(builder.annotationReplacers);
+        this.senderResolvers = copyList(builder.senderResolvers);
+        this.validators = copyList(builder.validators);
+        this.responseHandlers = copyList(builder.responseHandlers);
+        this.commandConditions = copyList(builder.conditions);
+        //noinspection rawtypes
+        this.permissionFactories = (List) copyList(builder.permissionFactories);
+        this.dependencies = copyMap(builder.dependencies);
         this.messageSender = builder.messageSender;
         this.errorSender = builder.errorSender;
         this.parameterNamingStrategy = builder.namingStrategy;
@@ -294,7 +298,8 @@ public final class Lamp<A extends CommandActor> {
             if (instance instanceof Orphans) {
                 throw new IllegalArgumentException("You forgot to call .handler(OrphanCommand) in your Orphans.path(...)!");
             }
-            if (instance instanceof OrphanRegistry registry) {
+            if (instance instanceof OrphanRegistry) {
+                OrphanRegistry registry = (OrphanRegistry) instance;
                 commandClass = registry.handler().getClass();
                 instance = registry.handler();
                 return tree.register(commandClass, instance, registry.paths());

--- a/common/src/main/java/revxrsal/commands/annotation/list/AnnotationListFromMap.java
+++ b/common/src/main/java/revxrsal/commands/annotation/list/AnnotationListFromMap.java
@@ -85,7 +85,7 @@ final class AnnotationListFromMap implements AnnotationList {
     ) {
         Class<?> top = element.getDeclaringClass();
         while (top != null) {
-            var classAnnotations = AnnotationList.create(top)
+            AnnotationList classAnnotations = AnnotationList.create(top)
                     .replaceAnnotations(top, replacers);
             for (Annotation annotation : classAnnotations) {
                 if (annotation.annotationType().isAnnotationPresent(DistributeOnMethods.class))
@@ -154,7 +154,8 @@ final class AnnotationListFromMap implements AnnotationList {
                     annotations.putAll(toMap(newAnnotations));
             }
         }
-        if (element instanceof Method method) {
+        if (element instanceof Method) {
+            Method method = (Method) element;
             distributeAnnotations(annotations, method, replacers);
         }
         return new AnnotationListFromMap(annotations);
@@ -186,7 +187,7 @@ final class AnnotationListFromMap implements AnnotationList {
 
     @Override
     public @NotNull AnnotationList withAnnotations(boolean overrideExisting, @NotNull Annotation... annotations) {
-        var map = new HashMap<>(this.annotations);
+        HashMap<Class<? extends Annotation>, Annotation> map = new HashMap<>(this.annotations);
         for (@NotNull Annotation annotation : annotations) {
             if (overrideExisting)
                 map.put(annotation.annotationType(), annotation);

--- a/common/src/main/java/revxrsal/commands/annotation/list/EmptyAnnotationList.java
+++ b/common/src/main/java/revxrsal/commands/annotation/list/EmptyAnnotationList.java
@@ -100,7 +100,7 @@ final class EmptyAnnotationList implements AnnotationList {
 
     @Override
     public @NotNull AnnotationList withAnnotations(boolean overrideExisting, @NotNull Annotation... annotations) {
-        var map = AnnotationListFromMap.toMap(annotations);
+        Map<Class<? extends Annotation>, Annotation> map = AnnotationListFromMap.toMap(annotations);
         return new AnnotationListFromMap(map);
     }
 

--- a/common/src/main/java/revxrsal/commands/autocomplete/AsyncSuggestionProvider.java
+++ b/common/src/main/java/revxrsal/commands/autocomplete/AsyncSuggestionProvider.java
@@ -43,6 +43,17 @@ import java.util.concurrent.CompletableFuture;
 public interface AsyncSuggestionProvider<A extends CommandActor> extends BaseSuggestionProvider {
 
     /**
+     * Creates a {@link AsyncSuggestionProvider} from the given {@link SuggestionProvider}
+     *
+     * @param provider Provider to wrap
+     * @param <A>      The actor type
+     * @return The {@link AsyncSuggestionProvider}
+     */
+    static <A extends CommandActor> @NotNull AsyncSuggestionProvider<A> from(@NotNull SuggestionProvider<A> provider) {
+        return context -> CompletableFuture.supplyAsync(() -> provider.getSuggestions(context));
+    }
+
+    /**
      * Returns the suggestions
      *
      * @param context The execution context. This will try to parse
@@ -52,15 +63,4 @@ public interface AsyncSuggestionProvider<A extends CommandActor> extends BaseSug
      */
     @NotNull
     CompletableFuture<Collection<String>> getSuggestionsAsync(@NotNull ExecutionContext<A> context);
-
-    /**
-     * Creates a {@link AsyncSuggestionProvider} from the given {@link SuggestionProvider}
-     *
-     * @param provider Provider to wrap
-     * @param <A> The actor type
-     * @return The {@link AsyncSuggestionProvider}
-     */
-    static <A extends CommandActor> @NotNull AsyncSuggestionProvider<A> from(@NotNull SuggestionProvider<A> provider) {
-        return context -> CompletableFuture.supplyAsync(() -> provider.getSuggestions(context));
-    }
 }

--- a/common/src/main/java/revxrsal/commands/autocomplete/ClassSuggestionProviderFactory.java
+++ b/common/src/main/java/revxrsal/commands/autocomplete/ClassSuggestionProviderFactory.java
@@ -30,6 +30,7 @@ import revxrsal.commands.annotation.list.AnnotationList;
 import revxrsal.commands.command.CommandActor;
 
 import java.lang.reflect.Type;
+import java.util.Objects;
 
 import static revxrsal.commands.util.Classes.getRawType;
 import static revxrsal.commands.util.Classes.wrap;
@@ -40,14 +41,12 @@ import static revxrsal.commands.util.Classes.wrap;
  * <p>
  * Create using {@link SuggestionProvider.Factory#forType(Class, SuggestionProvider)}
  * and {@link SuggestionProvider.Factory#forTypeAndSubclasses(Class, SuggestionProvider)}
- *
- * @param <A> The actor type
  */
-record ClassSuggestionProviderFactory<A extends CommandActor>(
-        Class<?> type,
-        SuggestionProvider<A> provider,
-        boolean allowSubclasses
-) implements SuggestionProvider.Factory<A> {
+final class ClassSuggestionProviderFactory<A extends CommandActor> implements SuggestionProvider.Factory<A> {
+    private final Class<?> type;
+    private final SuggestionProvider<A> provider;
+    private final boolean allowSubclasses;
+
 
     ClassSuggestionProviderFactory(Class<?> type, SuggestionProvider<A> provider, boolean allowSubclasses) {
         this.type = wrap(type);
@@ -65,4 +64,34 @@ record ClassSuggestionProviderFactory<A extends CommandActor>(
             return provider;
         return null;
     }
+
+    public Class<?> type() {return type;}
+
+    public SuggestionProvider<A> provider() {return provider;}
+
+    public boolean allowSubclasses() {return allowSubclasses;}
+
+    @Override
+    public boolean equals(Object obj) {
+        if (obj == this) return true;
+        if (obj == null || obj.getClass() != this.getClass()) return false;
+        ClassSuggestionProviderFactory that = (ClassSuggestionProviderFactory) obj;
+        return Objects.equals(this.type, that.type) &&
+                Objects.equals(this.provider, that.provider) &&
+                this.allowSubclasses == that.allowSubclasses;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(type, provider, allowSubclasses);
+    }
+
+    @Override
+    public String toString() {
+        return "ClassSuggestionProviderFactory[" +
+                "type=" + type + ", " +
+                "provider=" + provider + ", " +
+                "allowSubclasses=" + allowSubclasses + ']';
+    }
+
 }

--- a/common/src/main/java/revxrsal/commands/autocomplete/EmptySuggestionProvider.java
+++ b/common/src/main/java/revxrsal/commands/autocomplete/EmptySuggestionProvider.java
@@ -27,6 +27,7 @@ import org.jetbrains.annotations.NotNull;
 import revxrsal.commands.command.CommandActor;
 import revxrsal.commands.node.ExecutionContext;
 
+import java.util.Collections;
 import java.util.List;
 
 /**
@@ -41,7 +42,7 @@ final class EmptySuggestionProvider implements SuggestionProvider<CommandActor> 
 
     @Override
     public @NotNull List<String> getSuggestions(@NotNull ExecutionContext<CommandActor> context) {
-        return List.of();
+        return Collections.emptyList();
     }
 
     @Override

--- a/common/src/main/java/revxrsal/commands/autocomplete/SuggestWithProviderFactory.java
+++ b/common/src/main/java/revxrsal/commands/autocomplete/SuggestWithProviderFactory.java
@@ -47,11 +47,14 @@ enum SuggestWithProviderFactory implements SuggestionProvider.Factory<CommandAct
         if (suggestWith == null)
             return null;
         BaseSuggestionProvider type = InstanceCreator.create(suggestWith.value());
-        if (type instanceof SuggestionProvider<?> pType) {
+        if (type instanceof SuggestionProvider<?>) {
+            SuggestionProvider<?> pType = (SuggestionProvider<?>) type;
             return (SuggestionProvider<CommandActor>) pType;
-        } else if (type instanceof SuggestionProvider.Factory<?> factory) {
+        } else if (type instanceof SuggestionProvider.Factory<?>) {
+            SuggestionProvider.Factory<?> factory = (SuggestionProvider.Factory<?>) type;
             return factory.create(parameterType, annotations, (Lamp) lamp);
-        } else if (type instanceof AsyncSuggestionProvider<?> async) {
+        } else if (type instanceof AsyncSuggestionProvider<?>) {
+            AsyncSuggestionProvider<?> async = (AsyncSuggestionProvider<?>) type;
             return (SuggestionProvider<CommandActor>) SuggestionProvider.fromAsync(async);
         } else {
             throw new IllegalArgumentException("Don't know how to create a SuggestionProvider from " + type);

--- a/common/src/main/java/revxrsal/commands/autocomplete/SuggestionProvider.java
+++ b/common/src/main/java/revxrsal/commands/autocomplete/SuggestionProvider.java
@@ -33,6 +33,7 @@ import revxrsal.commands.node.ExecutionContext;
 
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Type;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 import java.util.function.Function;
@@ -65,7 +66,7 @@ public interface SuggestionProvider<A extends CommandActor> extends BaseSuggesti
      * block.
      *
      * @param provider The asynchronous provider
-     * @param <A> The actor type
+     * @param <A>      The actor type
      * @return The {@link SuggestionProvider}
      */
     @Contract("_ -> new")
@@ -83,7 +84,7 @@ public interface SuggestionProvider<A extends CommandActor> extends BaseSuggesti
     static <A extends CommandActor> @NotNull SuggestionProvider<A> of(@NotNull String... suggestions) {
         if (suggestions == null || suggestions.length == 0)
             return empty();
-        List<String> list = List.of(suggestions);
+        List<String> list = Arrays.asList(suggestions);
         return (context) -> list;
     }
 

--- a/common/src/main/java/revxrsal/commands/autocomplete/SuggestionProviders.java
+++ b/common/src/main/java/revxrsal/commands/autocomplete/SuggestionProviders.java
@@ -34,6 +34,7 @@ import revxrsal.commands.command.CommandParameter;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Type;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 import java.util.function.Function;
@@ -56,7 +57,7 @@ public final class SuggestionProviders<A extends CommandActor> {
      * <p>
      * These also will not be included in {@link #toBuilder()}.
      */
-    private static final List<Factory<?>> DEFAULT_FACTORIES = List.of(
+    private static final List<Factory<?>> DEFAULT_FACTORIES = Arrays.asList(
             SuggestAnnotationProviderFactory.INSTANCE,
             SuggestWithProviderFactory.INSTANCE
     );

--- a/common/src/main/java/revxrsal/commands/exception/DefaultExceptionHandler.java
+++ b/common/src/main/java/revxrsal/commands/exception/DefaultExceptionHandler.java
@@ -42,9 +42,15 @@ public class DefaultExceptionHandler<A extends CommandActor> extends RuntimeExce
     @HandleException
     public void onInputParse(@NotNull InputParseException e, @NotNull A actor) {
         switch (e.cause()) {
-            case INVALID_ESCAPE_CHARACTER -> actor.error("Invalid input. Use \\\\ to include a backslash.");
-            case UNCLOSED_QUOTE -> actor.error("Unclosed quote. Make sure to close all quotes.");
-            case EXPECTED_WHITESPACE -> actor.error("Expected whitespace to end one argument, but found trailing data");
+            case INVALID_ESCAPE_CHARACTER:
+                actor.error("Invalid input. Use \\\\ to include a backslash.");
+                break;
+            case UNCLOSED_QUOTE:
+                actor.error("Unclosed quote. Make sure to close all quotes.");
+                break;
+            case EXPECTED_WHITESPACE:
+                actor.error("Expected whitespace to end one argument, but found trailing data.");
+                break;
         }
     }
 

--- a/common/src/main/java/revxrsal/commands/exception/RuntimeExceptionAdapter.java
+++ b/common/src/main/java/revxrsal/commands/exception/RuntimeExceptionAdapter.java
@@ -108,7 +108,7 @@ public class RuntimeExceptionAdapter<A extends CommandActor> implements CommandE
         for (Method method : Reflections.getAllMethods(getClass())) {
             if (!isHandler(method))
                 continue;
-            var handler = createHandler(method);
+            CommandExceptionHandler<A> handler = createHandler(method);
             handlers.add(handler);
         }
     }
@@ -164,15 +164,15 @@ public class RuntimeExceptionAdapter<A extends CommandActor> implements CommandE
                 suppliers[i] = (throwable, errorContext) -> errorContext.context().command().function();
             } else if (CommandParameter.class.isAssignableFrom(type)) {
                 /* handle a CommandParameter parameter */
-                conditions.add((throwable, errorContext) -> errorContext instanceof ParsingParameter<A>);
+                conditions.add((throwable, errorContext) -> errorContext instanceof ParsingParameter);
                 suppliers[i] = (throwable, errorContext) -> ((ParsingParameter<A>) errorContext).parameter().parameter();
             } else if (ParameterNode.class.isAssignableFrom(type)) {
                 /* handle a ParameterNode parameter */
-                conditions.add((throwable, errorContext) -> errorContext instanceof ParsingParameter<A>);
+                conditions.add((throwable, errorContext) -> errorContext instanceof ParsingParameter);
                 suppliers[i] = (throwable, errorContext) -> ((ParsingParameter<A>) errorContext).parameter();
             } else if (LiteralNode.class.isAssignableFrom(type)) {
                 /* handle a LiteralNode parameter */
-                conditions.add((throwable, errorContext) -> errorContext instanceof ParsingLiteral<A>);
+                conditions.add((throwable, errorContext) -> errorContext instanceof ParsingLiteral);
                 suppliers[i] = (throwable, errorContext) -> ((ParsingLiteral<A>) errorContext).literal();
             } else {
                 throw new IllegalArgumentException("Don't know how to handle parameter of type " + type + " for a @HandleException function (" + method + ")");
@@ -200,7 +200,7 @@ public class RuntimeExceptionAdapter<A extends CommandActor> implements CommandE
 
     @Override
     public final void handleException(@NotNull Throwable throwable, @NotNull ErrorContext<A> errorContext) {
-        for (var handler : handlers) {
+        for (CommandExceptionHandler<A> handler : handlers) {
             handler.handleException(throwable, errorContext);
         }
     }

--- a/common/src/main/java/revxrsal/commands/exception/context/ErrorContext.java
+++ b/common/src/main/java/revxrsal/commands/exception/context/ErrorContext.java
@@ -144,7 +144,7 @@ public interface ErrorContext<A extends CommandActor> {
      * @return whether the error occurred during parsing a literal
      */
     default boolean isParsingLiteral() {
-        return this instanceof ParsingLiteral<A>;
+        return this instanceof ParsingLiteral;
     }
 
     /**
@@ -153,7 +153,7 @@ public interface ErrorContext<A extends CommandActor> {
      * @return whether the error occurred during parsing a parameter
      */
     default boolean isParsingParameter() {
-        return this instanceof ParsingParameter<A>;
+        return this instanceof ParsingParameter;
     }
 
     /**
@@ -162,7 +162,7 @@ public interface ErrorContext<A extends CommandActor> {
      * @return whether the error occurred during executing a function
      */
     default boolean isExecutingFunction() {
-        return this instanceof ExecutingFunctionContext<A>;
+        return this instanceof ExecutingFunctionContext;
     }
 
     /**

--- a/common/src/main/java/revxrsal/commands/exception/context/ExecutingFunctionContext.java
+++ b/common/src/main/java/revxrsal/commands/exception/context/ExecutingFunctionContext.java
@@ -28,13 +28,22 @@ import revxrsal.commands.Lamp;
 import revxrsal.commands.command.CommandActor;
 import revxrsal.commands.node.ExecutionContext;
 
+import java.util.Objects;
+
 /**
  * Right now this context stores no information. We can just use
  * a singleton for it
  */
-record ExecutingFunctionContext<A extends CommandActor>(
-        ExecutionContext<A> context
-) implements ErrorContext.ExecutingFunction<A> {
+final class ExecutingFunctionContext<A extends CommandActor> implements ErrorContext.ExecutingFunction<A> {
+    private final ExecutionContext<A> context;
+
+    /**
+     *
+     */
+    ExecutingFunctionContext(
+            ExecutionContext<A> context
+    ) {this.context = context;}
+
     @Override
     public @NotNull A actor() {
         return context.actor();
@@ -44,4 +53,26 @@ record ExecutingFunctionContext<A extends CommandActor>(
     public @NotNull Lamp<A> lamp() {
         return context.lamp();
     }
+
+    @Override public ExecutionContext<A> context() {return context;}
+
+    @Override
+    public boolean equals(Object obj) {
+        if (obj == this) return true;
+        if (obj == null || obj.getClass() != this.getClass()) return false;
+        ExecutingFunctionContext that = (ExecutingFunctionContext) obj;
+        return Objects.equals(this.context, that.context);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(context);
+    }
+
+    @Override
+    public String toString() {
+        return "ExecutingFunctionContext[" +
+                "context=" + context + ']';
+    }
+
 }

--- a/common/src/main/java/revxrsal/commands/exception/context/ParsingLiteralContext.java
+++ b/common/src/main/java/revxrsal/commands/exception/context/ParsingLiteralContext.java
@@ -29,10 +29,20 @@ import revxrsal.commands.command.CommandActor;
 import revxrsal.commands.node.ExecutionContext;
 import revxrsal.commands.node.LiteralNode;
 
-record ParsingLiteralContext<A extends CommandActor>(
-        @NotNull ExecutionContext<A> context,
-        @NotNull LiteralNode<A> literal
-) implements ErrorContext.ParsingLiteral<A> {
+import java.util.Objects;
+
+final class ParsingLiteralContext<A extends CommandActor> implements ErrorContext.ParsingLiteral<A> {
+    private final @NotNull ExecutionContext<A> context;
+    private final @NotNull LiteralNode<A> literal;
+
+    ParsingLiteralContext(
+            @NotNull ExecutionContext<A> context,
+            @NotNull LiteralNode<A> literal
+    ) {
+        this.context = context;
+        this.literal = literal;
+    }
+
     @Override
     public @NotNull A actor() {
         return context().actor();
@@ -42,4 +52,30 @@ record ParsingLiteralContext<A extends CommandActor>(
     public @NotNull Lamp<A> lamp() {
         return context.lamp();
     }
+
+    @Override public @NotNull ExecutionContext<A> context() {return context;}
+
+    @Override public @NotNull LiteralNode<A> literal() {return literal;}
+
+    @Override
+    public boolean equals(Object obj) {
+        if (obj == this) return true;
+        if (obj == null || obj.getClass() != this.getClass()) return false;
+        ParsingLiteralContext that = (ParsingLiteralContext) obj;
+        return Objects.equals(this.context, that.context) &&
+                Objects.equals(this.literal, that.literal);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(context, literal);
+    }
+
+    @Override
+    public String toString() {
+        return "ParsingLiteralContext[" +
+                "context=" + context + ", " +
+                "literal=" + literal + ']';
+    }
+
 }

--- a/common/src/main/java/revxrsal/commands/exception/context/ParsingParameterContext.java
+++ b/common/src/main/java/revxrsal/commands/exception/context/ParsingParameterContext.java
@@ -30,11 +30,23 @@ import revxrsal.commands.node.ExecutionContext;
 import revxrsal.commands.node.ParameterNode;
 import revxrsal.commands.stream.StringStream;
 
-record ParsingParameterContext<A extends CommandActor>(
-        @NotNull ExecutionContext<A> context,
-        @NotNull ParameterNode<A, ?> parameter,
-        @NotNull StringStream input
-) implements ErrorContext.ParsingParameter<A> {
+import java.util.Objects;
+
+final class ParsingParameterContext<A extends CommandActor> implements ErrorContext.ParsingParameter<A> {
+    private final @NotNull ExecutionContext<A> context;
+    private final @NotNull ParameterNode<A, ?> parameter;
+    private final @NotNull StringStream input;
+
+    ParsingParameterContext(
+            @NotNull ExecutionContext<A> context,
+            @NotNull ParameterNode<A, ?> parameter,
+            @NotNull StringStream input
+    ) {
+        this.context = context;
+        this.parameter = parameter;
+        this.input = input;
+    }
+
     @Override
     public @NotNull A actor() {
         return context.actor();
@@ -44,4 +56,34 @@ record ParsingParameterContext<A extends CommandActor>(
     public @NotNull Lamp<A> lamp() {
         return context.lamp();
     }
+
+    @Override public @NotNull ExecutionContext<A> context() {return context;}
+
+    @Override public @NotNull ParameterNode<A, ?> parameter() {return parameter;}
+
+    public @NotNull StringStream input() {return input;}
+
+    @Override
+    public boolean equals(Object obj) {
+        if (obj == this) return true;
+        if (obj == null || obj.getClass() != this.getClass()) return false;
+        ParsingParameterContext that = (ParsingParameterContext) obj;
+        return Objects.equals(this.context, that.context) &&
+                Objects.equals(this.parameter, that.parameter) &&
+                Objects.equals(this.input, that.input);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(context, parameter, input);
+    }
+
+    @Override
+    public String toString() {
+        return "ParsingParameterContext[" +
+                "context=" + context + ", " +
+                "parameter=" + parameter + ", " +
+                "input=" + input + ']';
+    }
+
 }

--- a/common/src/main/java/revxrsal/commands/exception/context/UnknownCommandContext.java
+++ b/common/src/main/java/revxrsal/commands/exception/context/UnknownCommandContext.java
@@ -28,11 +28,19 @@ import revxrsal.commands.Lamp;
 import revxrsal.commands.command.CommandActor;
 import revxrsal.commands.node.ExecutionContext;
 
+import java.util.Objects;
+
 /**
  * Right now this context stores no information. We can just use
  * a singleton for it
  */
-record UnknownCommandContext<A extends CommandActor>(@NotNull A actor) implements ErrorContext.UnknownCommand<A> {
+final class UnknownCommandContext<A extends CommandActor> implements ErrorContext.UnknownCommand<A> {
+    private final @NotNull A actor;
+
+    /**
+     *
+     */
+    UnknownCommandContext(@NotNull A actor) {this.actor = actor;}
 
     @Override
     public boolean hasExecutionContext() {
@@ -53,4 +61,24 @@ record UnknownCommandContext<A extends CommandActor>(@NotNull A actor) implement
     public @NotNull Lamp<A> lamp() {
         return (Lamp<A>) actor.lamp();
     }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (obj == this) return true;
+        if (obj == null || obj.getClass() != this.getClass()) return false;
+        UnknownCommandContext that = (UnknownCommandContext) obj;
+        return Objects.equals(this.actor, that.actor);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(actor);
+    }
+
+    @Override
+    public String toString() {
+        return "UnknownCommandContext[" +
+                "actor=" + actor + ']';
+    }
+
 }

--- a/common/src/main/java/revxrsal/commands/exception/context/UnknownParameterContext.java
+++ b/common/src/main/java/revxrsal/commands/exception/context/UnknownParameterContext.java
@@ -28,14 +28,22 @@ import revxrsal.commands.Lamp;
 import revxrsal.commands.command.CommandActor;
 import revxrsal.commands.node.ExecutionContext;
 
+import java.util.Objects;
+
 /**
  * Right now this context stores no information. We can just use
  * a singleton for it
  */
-record UnknownParameterContext<A extends CommandActor>(
-        @NotNull ExecutionContext<A> context
+final class UnknownParameterContext<A extends CommandActor> implements ErrorContext.UnknownParameter<A> {
+    private final @NotNull ExecutionContext<A> context;
 
-) implements ErrorContext.UnknownParameter<A> {
+    /**
+     *
+     */
+    UnknownParameterContext(
+            @NotNull ExecutionContext<A> context
+
+    ) {this.context = context;}
 
     @Override
     public boolean hasExecutionContext() {
@@ -51,4 +59,26 @@ record UnknownParameterContext<A extends CommandActor>(
     public @NotNull Lamp<A> lamp() {
         return context.lamp();
     }
+
+    @Override public @NotNull ExecutionContext<A> context() {return context;}
+
+    @Override
+    public boolean equals(Object obj) {
+        if (obj == this) return true;
+        if (obj == null || obj.getClass() != this.getClass()) return false;
+        UnknownParameterContext that = (UnknownParameterContext) obj;
+        return Objects.equals(this.context, that.context);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(context);
+    }
+
+    @Override
+    public String toString() {
+        return "UnknownParameterContext[" +
+                "context=" + context + ']';
+    }
+
 }

--- a/common/src/main/java/revxrsal/commands/help/Help.java
+++ b/common/src/main/java/revxrsal/commands/help/Help.java
@@ -58,7 +58,7 @@ public interface Help {
             @Range(from = 1, to = Integer.MAX_VALUE) int elementsPerPage
     ) throws InvalidHelpPageException {
         if (commands.isEmpty())
-            return List.of();
+            return Collections.emptyList();
         int size = numberOfPages(commands.size(), elementsPerPage);
         if (page <= 0)
             throw new InvalidHelpPageException(commands, page, elementsPerPage, size);
@@ -124,28 +124,6 @@ public interface Help {
          */
         @Range(from = 1, to = Integer.MAX_VALUE)
         int numberOfPages(@Range(from = 1, to = Integer.MAX_VALUE) int elementsPerPage);
-
-        /**
-         * Returns the list of commands that belong to a specific page after paginating
-         * this list.
-         * <p>
-         * Note that the list returned by this method is immutable.
-         *
-         * @param pageNumber      The page number
-         * @param elementsPerPage The elements to include in each page
-         * @return The pages list.
-         * @throws InvalidHelpPageException if {@code pageNumber} is greater than
-         *                                  {@link #numberOfPages(int)} or less than 1
-         * @deprecated Use {@link #paginate(int, int)} instead.
-         */
-        @Unmodifiable
-        @Deprecated(forRemoval = true)
-        default List<ExecutableCommand<A>> asPage(
-                @Range(from = 1, to = Integer.MAX_VALUE) int pageNumber,
-                @Range(from = 1, to = Integer.MAX_VALUE) int elementsPerPage
-        ) throws InvalidHelpPageException {
-            return paginate(pageNumber, elementsPerPage);
-        }
 
         /**
          * Returns the list of commands that belong to a specific page after paginating

--- a/common/src/main/java/revxrsal/commands/hook/Hooks.java
+++ b/common/src/main/java/revxrsal/commands/hook/Hooks.java
@@ -35,6 +35,7 @@ import revxrsal.commands.node.ExecutionContext;
 import java.util.ArrayList;
 import java.util.List;
 
+import static revxrsal.commands.util.Collections.copyList;
 import static revxrsal.commands.util.Preconditions.notNull;
 
 /**
@@ -55,7 +56,7 @@ public final class Hooks<A extends CommandActor> {
     private final @Unmodifiable List<Hook> hooks;
 
     private Hooks(Builder<A> builder) {
-        this.hooks = List.copyOf(builder.hooks);
+        this.hooks = copyList(builder.hooks);
     }
 
     /**
@@ -89,8 +90,10 @@ public final class Hooks<A extends CommandActor> {
     public boolean onCommandRegistered(@NotNull ExecutableCommand<A> command) {
         CancelHandle cancelHandle = newCancelHandle();
         for (Hook hook : hooks) {
-            if (hook instanceof CommandRegisteredHook registeredHook)
+            if (hook instanceof CommandRegisteredHook) {
+                CommandRegisteredHook registeredHook = (CommandRegisteredHook) hook;
                 registeredHook.onRegistered(command, cancelHandle);
+            }
         }
         return !cancelHandle.wasCancelled();
     }
@@ -106,8 +109,10 @@ public final class Hooks<A extends CommandActor> {
     public boolean onCommandUnregistered(@NotNull ExecutableCommand<A> command) {
         CancelHandle cancelHandle = newCancelHandle();
         for (Hook hook : hooks) {
-            if (hook instanceof CommandUnregisteredHook unregisteredHook)
+            if (hook instanceof CommandUnregisteredHook) {
+                CommandUnregisteredHook unregisteredHook = (CommandUnregisteredHook) hook;
                 unregisteredHook.onUnregistered(command, cancelHandle);
+            }
         }
         return !cancelHandle.wasCancelled();
     }
@@ -124,8 +129,10 @@ public final class Hooks<A extends CommandActor> {
     public boolean onCommandExecuted(@NotNull ExecutableCommand<A> command, @NotNull ExecutionContext<A> context) {
         CancelHandle cancelHandle = newCancelHandle();
         for (Hook hook : hooks) {
-            if (hook instanceof CommandExecutedHook executedHook)
+            if (hook instanceof CommandExecutedHook) {
+                CommandExecutedHook executedHook = (CommandExecutedHook) hook;
                 executedHook.onExecuted(command, context, cancelHandle);
+            }
         }
         return !cancelHandle.wasCancelled();
     }

--- a/common/src/main/java/revxrsal/commands/node/parser/BaseCommandRegistry.java
+++ b/common/src/main/java/revxrsal/commands/node/parser/BaseCommandRegistry.java
@@ -50,6 +50,7 @@ import java.lang.reflect.Method;
 import java.util.*;
 import java.util.function.Predicate;
 
+import static revxrsal.commands.util.Collections.copyList;
 import static revxrsal.commands.util.Collections.unmodifiableIterator;
 import static revxrsal.commands.util.Reflections.getAllMethods;
 
@@ -92,7 +93,7 @@ public final class BaseCommandRegistry<A extends CommandActor> implements Comman
             if (orphanPaths != null && !annotations.isEmpty()) {
                 if (orphanPaths.isEmpty())
                     throw new IllegalArgumentException("Cannot have an OrphanCommand with no paths (supplied from .path())");
-                String[] values = orphanPaths.toArray(String[]::new);
+                String[] values = orphanPaths.toArray(new String[0]);
                 annotations = annotations.withAnnotations(false, new DynamicCommand(values));
             }
 
@@ -110,7 +111,7 @@ public final class BaseCommandRegistry<A extends CommandActor> implements Comman
                 }
             }
         }
-        return List.copyOf(registered);
+        return copyList(registered);
     }
 
     private boolean isCommandMethod(AnnotationList annotations) {
@@ -210,11 +211,36 @@ public final class BaseCommandRegistry<A extends CommandActor> implements Comman
         return unmodifiableIterator(children.iterator());
     }
 
-    private record DynamicCommand(String[] value) implements Command {
+    private static final class DynamicCommand implements Command {
+        private final String[] value;
+
+        private DynamicCommand(String[] value) {this.value = value;}
 
         @Override
         public Class<? extends Annotation> annotationType() {
             return Command.class;
         }
+
+        @Override public String[] value() {return value;}
+
+        @Override
+        public boolean equals(Object obj) {
+            if (obj == this) return true;
+            if (obj == null || obj.getClass() != this.getClass()) return false;
+            DynamicCommand that = (DynamicCommand) obj;
+            return Objects.equals(this.value, that.value);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash((Object) value);
+        }
+
+        @Override
+        public String toString() {
+            return "DynamicCommand[" +
+                    "value=" + Arrays.toString(value) + ']';
+        }
+
     }
 }

--- a/common/src/main/java/revxrsal/commands/node/parser/FunctionParameter.java
+++ b/common/src/main/java/revxrsal/commands/node/parser/FunctionParameter.java
@@ -32,14 +32,28 @@ import java.lang.reflect.Method;
 import java.lang.reflect.Parameter;
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
 
-record FunctionParameter(
-        @NotNull Parameter parameter,
-        @NotNull String name,
-        @NotNull AnnotationList annotations,
-        int methodIndex
-) implements CommandParameter {
+final class FunctionParameter implements CommandParameter {
+    private final @NotNull Parameter parameter;
+    private final @NotNull String name;
+    private final @NotNull AnnotationList annotations;
+    private final int methodIndex;
+
+    FunctionParameter(
+            @NotNull Parameter parameter,
+            @NotNull String name,
+            @NotNull AnnotationList annotations,
+            int methodIndex
+    ) {
+        this.parameter = parameter;
+        this.name = name;
+        this.annotations = annotations;
+        this.methodIndex = methodIndex;
+    }
 
     @Override
     public boolean isLastInMethod() {
@@ -65,8 +79,8 @@ record FunctionParameter(
     public @NotNull List<Type> generics() {
         Type type = parameter.getParameterizedType();
         if (type instanceof ParameterizedType)
-            return List.of(((ParameterizedType) type).getActualTypeArguments());
-        return List.of();
+            return Arrays.asList(((ParameterizedType) type).getActualTypeArguments());
+        return Collections.emptyList();
     }
 
     @Override
@@ -83,4 +97,38 @@ record FunctionParameter(
             return length.min() == 0;
         return false;
     }
+
+    @Override public @NotNull Parameter parameter() {return parameter;}
+
+    @Override public @NotNull String name() {return name;}
+
+    @Override public @NotNull AnnotationList annotations() {return annotations;}
+
+    @Override public int methodIndex() {return methodIndex;}
+
+    @Override
+    public boolean equals(Object obj) {
+        if (obj == this) return true;
+        if (obj == null || obj.getClass() != this.getClass()) return false;
+        FunctionParameter that = (FunctionParameter) obj;
+        return Objects.equals(this.parameter, that.parameter) &&
+                Objects.equals(this.name, that.name) &&
+                Objects.equals(this.annotations, that.annotations) &&
+                this.methodIndex == that.methodIndex;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(parameter, name, annotations, methodIndex);
+    }
+
+    @Override
+    public String toString() {
+        return "FunctionParameter[" +
+                "parameter=" + parameter + ", " +
+                "name=" + name + ", " +
+                "annotations=" + annotations + ", " +
+                "methodIndex=" + methodIndex + ']';
+    }
+
 }

--- a/common/src/main/java/revxrsal/commands/node/parser/TreeParser.java
+++ b/common/src/main/java/revxrsal/commands/node/parser/TreeParser.java
@@ -198,9 +198,10 @@ public final class TreeParser<A extends CommandActor> {
     }
 
     private void validateFlagName(MutableCommandNode<A> node) {
-        if (!(node instanceof MutableParameterNode<?, ?> parameter)) {
+        if (!(node instanceof MutableParameterNode<?, ?>)) {
             return;
         }
+        MutableParameterNode<?, ?> parameter = (MutableParameterNode<?, ?>) node;
         Switch switchAnn = parameter.parameter().getAnnotation(Switch.class);
         Flag flag = parameter.parameter().getAnnotation(Flag.class);
         if (flag != null)
@@ -245,12 +246,12 @@ public final class TreeParser<A extends CommandActor> {
     }
 
     private boolean isOptional(MutableCommandNode<A> node) {
-        return node instanceof MutableParameterNode p && p.isOptional();
+        return node instanceof MutableParameterNode && ((MutableParameterNode) node).isOptional();
     }
 
     private boolean isFlagOrSwitch(MutableCommandNode<A> node) {
-        return node instanceof MutableParameterNode p && (
-                p.parameter().hasAnnotation(Switch.class) || p.parameter().hasAnnotation(Flag.class)
+        return node instanceof MutableParameterNode && (
+                ((MutableParameterNode) node).parameter().hasAnnotation(Switch.class) || ((MutableParameterNode) node).parameter().hasAnnotation(Flag.class)
         );
     }
 

--- a/common/src/main/java/revxrsal/commands/orphan/OrphanRegistry.java
+++ b/common/src/main/java/revxrsal/commands/orphan/OrphanRegistry.java
@@ -28,6 +28,7 @@ import org.jetbrains.annotations.Unmodifiable;
 import revxrsal.commands.Lamp;
 
 import java.util.List;
+import java.util.Objects;
 
 /**
  * Represents an orphan command that has finally found its parent path.
@@ -37,5 +38,42 @@ import java.util.List;
  * <p>
  * This should be constructed using {@link Orphans}'s methods.
  */
-public record OrphanRegistry(@NotNull @Unmodifiable List<String> paths, @NotNull OrphanCommand handler) {
+public final class OrphanRegistry {
+    private final @NotNull
+    @Unmodifiable List<String> paths;
+    private final @NotNull OrphanCommand handler;
+
+    /**
+     *
+     */
+    public OrphanRegistry(@NotNull @Unmodifiable List<String> paths, @NotNull OrphanCommand handler) {
+        this.paths = paths;
+        this.handler = handler;
+    }
+
+    public @NotNull @Unmodifiable List<String> paths() {return paths;}
+
+    public @NotNull OrphanCommand handler() {return handler;}
+
+    @Override
+    public boolean equals(Object obj) {
+        if (obj == this) return true;
+        if (obj == null || obj.getClass() != this.getClass()) return false;
+        OrphanRegistry that = (OrphanRegistry) obj;
+        return Objects.equals(this.paths, that.paths) &&
+                Objects.equals(this.handler, that.handler);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(paths, handler);
+    }
+
+    @Override
+    public String toString() {
+        return "OrphanRegistry[" +
+                "paths=" + paths + ", " +
+                "handler=" + handler + ']';
+    }
+
 }

--- a/common/src/main/java/revxrsal/commands/orphan/Orphans.java
+++ b/common/src/main/java/revxrsal/commands/orphan/Orphans.java
@@ -27,7 +27,9 @@ import org.jetbrains.annotations.NotNull;
 import revxrsal.commands.Lamp;
 import revxrsal.commands.annotation.Command;
 
+import java.util.Arrays;
 import java.util.List;
+import java.util.Objects;
 
 import static revxrsal.commands.util.Preconditions.notNull;
 
@@ -54,7 +56,13 @@ import static revxrsal.commands.util.Preconditions.notNull;
  *
  * @see OrphanCommand
  */
-public record Orphans(List<String> paths) {
+public final class Orphans {
+    private final List<String> paths;
+
+    /**
+     *
+     */
+    public Orphans(List<String> paths) {this.paths = paths;}
 
     /**
      * Starts the registration of an orphan command. The input for
@@ -70,7 +78,7 @@ public record Orphans(List<String> paths) {
      */
     public static Orphans path(@NotNull String... paths) {
         notNull(paths, "paths");
-        return new Orphans(List.of(paths));
+        return new Orphans(Arrays.asList(paths));
     }
 
     /**
@@ -85,4 +93,26 @@ public record Orphans(List<String> paths) {
         notNull(handler, "orphan command");
         return new OrphanRegistry(paths, handler);
     }
+
+    public List<String> paths() {return paths;}
+
+    @Override
+    public boolean equals(Object obj) {
+        if (obj == this) return true;
+        if (obj == null || obj.getClass() != this.getClass()) return false;
+        Orphans that = (Orphans) obj;
+        return Objects.equals(this.paths, that.paths);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(paths);
+    }
+
+    @Override
+    public String toString() {
+        return "Orphans[" +
+                "paths=" + paths + ']';
+    }
+
 }

--- a/common/src/main/java/revxrsal/commands/parameter/ParameterTypes.java
+++ b/common/src/main/java/revxrsal/commands/parameter/ParameterTypes.java
@@ -40,6 +40,7 @@ import revxrsal.commands.stream.StringStream;
 
 import java.lang.reflect.Type;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.UUID;
 
@@ -60,7 +61,7 @@ public final class ParameterTypes<A extends CommandActor> {
      * Highest priority factories. These come even before the user's
      * parameter types, but work in very specific conditions only.
      */
-    private static final List<ParameterFactory> HIGHEST_PRIORITY_FACTORIES = List.of(
+    private static final List<ParameterFactory> HIGHEST_PRIORITY_FACTORIES = Arrays.asList(
             ParseWithParameterTypeFactory.INSTANCE
     );
 
@@ -70,7 +71,7 @@ public final class ParameterTypes<A extends CommandActor> {
      * <p>
      * These also will not be included in {@link #toBuilder()}.
      */
-    private static final List<ParameterFactory> DEFAULT_FACTORIES = List.of(
+    private static final List<ParameterFactory> DEFAULT_FACTORIES = Arrays.asList(
             ArrayParameterTypeFactory.INSTANCE,
             ListParameterTypeFactory.INSTANCE,
             SetParameterTypeFactory.INSTANCE,

--- a/common/src/main/java/revxrsal/commands/parameter/PrioritySpec.java
+++ b/common/src/main/java/revxrsal/commands/parameter/PrioritySpec.java
@@ -27,6 +27,7 @@ import org.jetbrains.annotations.Contract;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.Comparator;
+import java.util.Objects;
 
 /**
  * Represents a priority specification for a certain {@link ParameterType}.
@@ -51,10 +52,8 @@ import java.util.Comparator;
  * will suffice.
  * <p>
  * {@link PrioritySpec} can be created using {@link #toBuilder()}.
- *
- * @param comparator The underlying comparator of this priority specification.
  */
-public record PrioritySpec(Comparator<ParameterType<?, ?>> comparator) {
+public final class PrioritySpec {
 
     /**
      * @see #defaultPriority()
@@ -78,6 +77,12 @@ public record PrioritySpec(Comparator<ParameterType<?, ?>> comparator) {
             return 0;
         return -1;
     });
+    private final Comparator<ParameterType<?, ?>> comparator;
+
+    /**
+     * @param comparator The underlying comparator of this priority specification.
+     */
+    public PrioritySpec(Comparator<ParameterType<?, ?>> comparator) {this.comparator = comparator;}
 
     /**
      * Creates a new {@link Builder}
@@ -136,6 +141,28 @@ public record PrioritySpec(Comparator<ParameterType<?, ?>> comparator) {
     public @NotNull Builder toBuilder() {
         return new Builder(comparator);
     }
+
+    public Comparator<ParameterType<?, ?>> comparator() {return comparator;}
+
+    @Override
+    public boolean equals(Object obj) {
+        if (obj == this) return true;
+        if (obj == null || obj.getClass() != this.getClass()) return false;
+        PrioritySpec that = (PrioritySpec) obj;
+        return Objects.equals(this.comparator, that.comparator);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(comparator);
+    }
+
+    @Override
+    public String toString() {
+        return "PrioritySpec[" +
+                "comparator=" + comparator + ']';
+    }
+
 
     /**
      * A builder for creating a {@link PrioritySpec}.

--- a/common/src/main/java/revxrsal/commands/parameter/builtins/ClassContextParameterFactory.java
+++ b/common/src/main/java/revxrsal/commands/parameter/builtins/ClassContextParameterFactory.java
@@ -31,16 +31,17 @@ import revxrsal.commands.command.CommandActor;
 import revxrsal.commands.parameter.ContextParameter;
 
 import java.lang.reflect.Type;
+import java.util.Objects;
 
 import static revxrsal.commands.util.Classes.getRawType;
 import static revxrsal.commands.util.Classes.wrap;
 
 @ApiStatus.Internal
-public record ClassContextParameterFactory<A extends CommandActor, T>(
-        Class<?> type,
-        ContextParameter<A, T> parameterType,
-        boolean allowSubclasses
-) implements ContextParameter.Factory<A> {
+public final class ClassContextParameterFactory<A extends CommandActor, T> implements ContextParameter.Factory<A> {
+    private final Class<?> type;
+    private final ContextParameter<A, T> parameterType;
+    private final boolean allowSubclasses;
+
 
     public ClassContextParameterFactory(
             Class<?> type,
@@ -71,5 +72,27 @@ public record ClassContextParameterFactory<A extends CommandActor, T>(
                 "parameterType=" + parameterType + ", " +
                 "allowSubclasses=" + allowSubclasses + ']';
     }
+
+    public Class<?> type() {return type;}
+
+    public ContextParameter<A, T> parameterType() {return parameterType;}
+
+    public boolean allowSubclasses() {return allowSubclasses;}
+
+    @Override
+    public boolean equals(Object obj) {
+        if (obj == this) return true;
+        if (obj == null || obj.getClass() != this.getClass()) return false;
+        ClassContextParameterFactory that = (ClassContextParameterFactory) obj;
+        return Objects.equals(this.type, that.type) &&
+                Objects.equals(this.parameterType, that.parameterType) &&
+                this.allowSubclasses == that.allowSubclasses;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(type, parameterType, allowSubclasses);
+    }
+
 
 }

--- a/common/src/main/java/revxrsal/commands/parameter/builtins/ClassParameterTypeFactory.java
+++ b/common/src/main/java/revxrsal/commands/parameter/builtins/ClassParameterTypeFactory.java
@@ -29,19 +29,19 @@ import revxrsal.commands.Lamp;
 import revxrsal.commands.annotation.list.AnnotationList;
 import revxrsal.commands.command.CommandActor;
 import revxrsal.commands.parameter.ParameterType;
-import revxrsal.commands.util.Classes;
 
 import java.lang.reflect.Type;
+import java.util.Objects;
 
 import static revxrsal.commands.util.Classes.getRawType;
 import static revxrsal.commands.util.Classes.wrap;
 
 @ApiStatus.Internal
-public record ClassParameterTypeFactory<A extends CommandActor, T>(
-        Class<?> type,
-        ParameterType<A, T> parameterType,
-        boolean allowSubclasses
-) implements ParameterType.Factory<A> {
+public final class ClassParameterTypeFactory<A extends CommandActor, T> implements ParameterType.Factory<A> {
+    private final Class<?> type;
+    private final ParameterType<A, T> parameterType;
+    private final boolean allowSubclasses;
+
 
     public ClassParameterTypeFactory(Class<?> type, ParameterType<A, T> parameterType, boolean allowSubclasses) {
         this.type = wrap(type);
@@ -52,7 +52,7 @@ public record ClassParameterTypeFactory<A extends CommandActor, T>(
     @Override
     @SuppressWarnings("unchecked")
     public <L> ParameterType<A, L> create(@NotNull Type parameterType, @NotNull AnnotationList annotations, @NotNull Lamp<A> lamp) {
-        Class<?> pType = Classes.wrap(getRawType(parameterType));
+        Class<?> pType = wrap(getRawType(parameterType));
         if (allowSubclasses && type.isAssignableFrom(pType)) {
             return (ParameterType<A, L>) this.parameterType;
         }
@@ -60,4 +60,34 @@ public record ClassParameterTypeFactory<A extends CommandActor, T>(
             return (ParameterType<A, L>) this.parameterType;
         return null;
     }
+
+    public Class<?> type() {return type;}
+
+    public ParameterType<A, T> parameterType() {return parameterType;}
+
+    public boolean allowSubclasses() {return allowSubclasses;}
+
+    @Override
+    public boolean equals(Object obj) {
+        if (obj == this) return true;
+        if (obj == null || obj.getClass() != this.getClass()) return false;
+        ClassParameterTypeFactory that = (ClassParameterTypeFactory) obj;
+        return Objects.equals(this.type, that.type) &&
+                Objects.equals(this.parameterType, that.parameterType) &&
+                this.allowSubclasses == that.allowSubclasses;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(type, parameterType, allowSubclasses);
+    }
+
+    @Override
+    public String toString() {
+        return "ClassParameterTypeFactory[" +
+                "type=" + type + ", " +
+                "parameterType=" + parameterType + ", " +
+                "allowSubclasses=" + allowSubclasses + ']';
+    }
+
 }

--- a/common/src/main/java/revxrsal/commands/parameter/builtins/CollectionParameterTypeFactory.java
+++ b/common/src/main/java/revxrsal/commands/parameter/builtins/CollectionParameterTypeFactory.java
@@ -42,6 +42,7 @@ import revxrsal.commands.util.Classes;
 
 import java.lang.reflect.Type;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
 import static revxrsal.commands.autocomplete.SuggestionProvider.empty;
@@ -137,7 +138,7 @@ abstract class CollectionParameterTypeFactory implements ParameterType.Factory<C
             if (paramSuggestions.equals(empty()))
                 return empty();
             return (context) -> {
-                List<String> inputted = List.of(context.input().peekRemaining().split(Character.toString(delimiter)));
+                List<String> inputted = Arrays.asList(context.input().peekRemaining().split(Character.toString(delimiter)));
                 if (preventsDuplicates()) {
                     return filter(
                             paramSuggestions.getSuggestions(context),

--- a/common/src/main/java/revxrsal/commands/parameter/builtins/EnumParameterTypeFactory.java
+++ b/common/src/main/java/revxrsal/commands/parameter/builtins/EnumParameterTypeFactory.java
@@ -36,10 +36,7 @@ import revxrsal.commands.parameter.PrioritySpec;
 import revxrsal.commands.stream.MutableStringStream;
 
 import java.lang.reflect.Type;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
 import static revxrsal.commands.util.Classes.getRawType;
 
@@ -64,10 +61,17 @@ public enum EnumParameterTypeFactory implements ParameterType.Factory<CommandAct
         return new EnumParameterType(byKeys, suggestions);
     }
 
-    private record EnumParameterType<E extends Enum<E>>(
-            Map<String, E> byKeys,
-            List<String> suggestions
-    ) implements ParameterType<CommandActor, E> {
+    private static final class EnumParameterType<E extends Enum<E>> implements ParameterType<CommandActor, E> {
+        private final Map<String, E> byKeys;
+        private final List<String> suggestions;
+
+        private EnumParameterType(
+                Map<String, E> byKeys,
+                List<String> suggestions
+        ) {
+            this.byKeys = byKeys;
+            this.suggestions = suggestions;
+        }
 
         @Override
         public E parse(@NotNull MutableStringStream input, @NotNull ExecutionContext<CommandActor> context) {
@@ -86,5 +90,31 @@ public enum EnumParameterTypeFactory implements ParameterType.Factory<CommandAct
         public @NotNull PrioritySpec parsePriority() {
             return PrioritySpec.highest();
         }
+
+        public Map<String, E> byKeys() {return byKeys;}
+
+        public List<String> suggestions() {return suggestions;}
+
+        @Override
+        public boolean equals(Object obj) {
+            if (obj == this) return true;
+            if (obj == null || obj.getClass() != this.getClass()) return false;
+            EnumParameterType that = (EnumParameterType) obj;
+            return Objects.equals(this.byKeys, that.byKeys) &&
+                    Objects.equals(this.suggestions, that.suggestions);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(byKeys, suggestions);
+        }
+
+        @Override
+        public String toString() {
+            return "EnumParameterType[" +
+                    "byKeys=" + byKeys + ", " +
+                    "suggestions=" + suggestions + ']';
+        }
+
     }
 }

--- a/common/src/main/java/revxrsal/commands/parameter/builtins/ParseWithParameterTypeFactory.java
+++ b/common/src/main/java/revxrsal/commands/parameter/builtins/ParseWithParameterTypeFactory.java
@@ -45,9 +45,11 @@ public enum ParseWithParameterTypeFactory implements ParameterType.Factory<Comma
         if (parseWith == null)
             return null;
         BaseParameterType type = InstanceCreator.create(parseWith.value());
-        if (type instanceof ParameterType<?, ?> pType) {
+        if (type instanceof ParameterType<?, ?>) {
+            ParameterType<?, ?> pType = (ParameterType<?, ?>) type;
             return (ParameterType<CommandActor, T>) pType;
-        } else if (type instanceof ParameterType.Factory<?> factory) {
+        } else if (type instanceof ParameterType.Factory<?>) {
+            ParameterType.Factory<?> factory = (ParameterType.Factory<?>) type;
             return factory.create(parameterType, annotations, (Lamp) lamp);
         } else {
             throw new IllegalArgumentException("Don't know how to create a ParameterType from " + type);

--- a/common/src/main/java/revxrsal/commands/parameter/builtins/SenderContextParameter.java
+++ b/common/src/main/java/revxrsal/commands/parameter/builtins/SenderContextParameter.java
@@ -30,11 +30,16 @@ import revxrsal.commands.node.ExecutionContext;
 import revxrsal.commands.parameter.ContextParameter;
 import revxrsal.commands.process.SenderResolver;
 
+import java.util.Objects;
+
 import static revxrsal.commands.util.Preconditions.notNull;
 
-public record SenderContextParameter<A extends CommandActor, T>(
-        SenderResolver<A> resolver
-) implements ContextParameter<A, T> {
+public final class SenderContextParameter<A extends CommandActor, T> implements ContextParameter<A, T> {
+    private final SenderResolver<A> resolver;
+
+    public SenderContextParameter(
+            SenderResolver<A> resolver
+    ) {this.resolver = resolver;}
 
     @Override
     public T resolve(@NotNull CommandParameter parameter, @NotNull ExecutionContext<A> context) {
@@ -44,4 +49,26 @@ public record SenderContextParameter<A extends CommandActor, T>(
         //noinspection unchecked
         return (T) sender;
     }
+
+    public SenderResolver<A> resolver() {return resolver;}
+
+    @Override
+    public boolean equals(Object obj) {
+        if (obj == this) return true;
+        if (obj == null || obj.getClass() != this.getClass()) return false;
+        SenderContextParameter that = (SenderContextParameter) obj;
+        return Objects.equals(this.resolver, that.resolver);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(resolver);
+    }
+
+    @Override
+    public String toString() {
+        return "SenderContextParameter[" +
+                "resolver=" + resolver + ']';
+    }
+
 }

--- a/common/src/main/java/revxrsal/commands/reflect/ktx/CallableMethod.java
+++ b/common/src/main/java/revxrsal/commands/reflect/ktx/CallableMethod.java
@@ -27,6 +27,7 @@ import org.jetbrains.annotations.NotNull;
 import revxrsal.commands.reflect.MethodCaller;
 
 import java.lang.reflect.Method;
+import java.util.Objects;
 
 /**
  * A utility class that combines a {@link Method} with a {@link MethodCaller}.
@@ -34,8 +35,44 @@ import java.lang.reflect.Method;
  * This class is immutable, therefore is safe to share across multiple
  * threads.
  */
-public record CallableMethod(
-        @NotNull Method method,
-        @NotNull MethodCaller caller
-) {
+public final class CallableMethod {
+    private final @NotNull Method method;
+    private final @NotNull MethodCaller caller;
+
+    /**
+     *
+     */
+    public CallableMethod(
+            @NotNull Method method,
+            @NotNull MethodCaller caller
+    ) {
+        this.method = method;
+        this.caller = caller;
+    }
+
+    public @NotNull Method method() {return method;}
+
+    public @NotNull MethodCaller caller() {return caller;}
+
+    @Override
+    public boolean equals(Object obj) {
+        if (obj == this) return true;
+        if (obj == null || obj.getClass() != this.getClass()) return false;
+        CallableMethod that = (CallableMethod) obj;
+        return Objects.equals(this.method, that.method) &&
+                Objects.equals(this.caller, that.caller);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(method, caller);
+    }
+
+    @Override
+    public String toString() {
+        return "CallableMethod[" +
+                "method=" + method + ", " +
+                "caller=" + caller + ']';
+    }
+
 }

--- a/common/src/main/java/revxrsal/commands/reflect/ktx/KotlinFunctionImpl.java
+++ b/common/src/main/java/revxrsal/commands/reflect/ktx/KotlinFunctionImpl.java
@@ -40,7 +40,8 @@ import static revxrsal.commands.reflect.ktx.DefaultFunctionFinder.findDefaultFun
 import static revxrsal.commands.reflect.ktx.KotlinConstants.continuation;
 import static revxrsal.commands.reflect.ktx.KotlinConstants.defaultPrimitiveValue;
 import static revxrsal.commands.reflect.ktx.KotlinSingletons.getCallerForNonDefault;
-import static revxrsal.commands.util.Collections.*;
+import static revxrsal.commands.util.Collections.getOrNull;
+import static revxrsal.commands.util.Collections.mapKeys;
 import static revxrsal.commands.util.Lazy.of;
 
 final class KotlinFunctionImpl implements KotlinFunction {
@@ -170,13 +171,11 @@ final class KotlinFunctionImpl implements KotlinFunction {
             if (mainMethod.method().getParameterCount() == args.size())
                 //noinspection unchecked
                 return (T) mainMethod.caller().call(instance, args.toArray());
-            throw new IllegalArgumentException("""
-                    Unable to invoke function with default parameters.\s
-                    This may happen because you have an @Optional non-null primitive type (e.g. Int) \
-                    with no default value using @Default or a Kotlin-default value.
-                    It may also occur if you have @Switch with no default value. (@Switch param: Boolean = ...)
-                    Either mark it as nullable, add a default value (@Optional param: Type = ...), or use @Default"""
-            );
+            throw new IllegalArgumentException("Unable to invoke function with default parameters. " +
+                    "This may happen because you have an @Optional non-null primitive type (e.g. Int) " +
+                    "with no default value using @Default or a Kotlin-default value. " +
+                    "It may also occur if you have @Switch with no default value. (@Switch param: Boolean = ...). " +
+                    "Either mark it as nullable, add a default value (@Optional param: Type = ...), or use @Default");
         }
 
         masks.add(mask);

--- a/common/src/main/java/revxrsal/commands/response/ClassResponseHandlerFactory.java
+++ b/common/src/main/java/revxrsal/commands/response/ClassResponseHandlerFactory.java
@@ -30,16 +30,17 @@ import revxrsal.commands.annotation.list.AnnotationList;
 import revxrsal.commands.command.CommandActor;
 
 import java.lang.reflect.Type;
+import java.util.Objects;
 
 import static revxrsal.commands.util.Classes.getRawType;
 import static revxrsal.commands.util.Classes.wrap;
 
 @ApiStatus.Internal
-public record ClassResponseHandlerFactory<A extends CommandActor, T>(
-        Class<?> type,
-        ResponseHandler<A, T> responseHandler,
-        boolean allowSubclasses
-) implements ResponseHandler.Factory<A> {
+public final class ClassResponseHandlerFactory<A extends CommandActor, T> implements ResponseHandler.Factory<A> {
+    private final Class<?> type;
+    private final ResponseHandler<A, T> responseHandler;
+    private final boolean allowSubclasses;
+
 
     public ClassResponseHandlerFactory(Class<?> type, ResponseHandler<A, T> responseHandler, boolean allowSubclasses) {
         this.type = wrap(type);
@@ -58,4 +59,34 @@ public record ClassResponseHandlerFactory<A extends CommandActor, T>(
             return (ResponseHandler<A, L>) this.responseHandler;
         return null;
     }
+
+    public Class<?> type() {return type;}
+
+    public ResponseHandler<A, T> responseHandler() {return responseHandler;}
+
+    public boolean allowSubclasses() {return allowSubclasses;}
+
+    @Override
+    public boolean equals(Object obj) {
+        if (obj == this) return true;
+        if (obj == null || obj.getClass() != this.getClass()) return false;
+        ClassResponseHandlerFactory that = (ClassResponseHandlerFactory) obj;
+        return Objects.equals(this.type, that.type) &&
+                Objects.equals(this.responseHandler, that.responseHandler) &&
+                this.allowSubclasses == that.allowSubclasses;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(type, responseHandler, allowSubclasses);
+    }
+
+    @Override
+    public String toString() {
+        return "ClassResponseHandlerFactory[" +
+                "type=" + type + ", " +
+                "responseHandler=" + responseHandler + ", " +
+                "allowSubclasses=" + allowSubclasses + ']';
+    }
+
 }

--- a/common/src/main/java/revxrsal/commands/stream/MutableStringStreamImpl.java
+++ b/common/src/main/java/revxrsal/commands/stream/MutableStringStreamImpl.java
@@ -186,13 +186,17 @@ public final class MutableStringStreamImpl extends BaseStringStream implements M
 
     public boolean readBoolean() {
         String value = readString();
-        return switch (value.toLowerCase(Locale.ENGLISH)) {
-            case "true", "yes" -> true;
-            case "false", "no", "nope" -> false;
-            default -> {
+        switch (value.toLowerCase(Locale.ENGLISH)) {
+            case "true":
+            case "yes":
+                return true;
+            case "false":
+            case "no":
+            case "nope":
+                return false;
+            default:
                 throw new InvalidBooleanException(value);
-            }
-        };
+        }
     }
 
     public void setPosition(int pos) {

--- a/common/src/main/java/revxrsal/commands/stream/token/LiteralToken.java
+++ b/common/src/main/java/revxrsal/commands/stream/token/LiteralToken.java
@@ -23,5 +23,32 @@
  */
 package revxrsal.commands.stream.token;
 
-public record LiteralToken(String value) implements Token {
+import java.util.Objects;
+
+public final class LiteralToken implements Token {
+    private final String value;
+
+    public LiteralToken(String value) {this.value = value;}
+
+    public String value() {return value;}
+
+    @Override
+    public boolean equals(Object obj) {
+        if (obj == this) return true;
+        if (obj == null || obj.getClass() != this.getClass()) return false;
+        LiteralToken that = (LiteralToken) obj;
+        return Objects.equals(this.value, that.value);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(value);
+    }
+
+    @Override
+    public String toString() {
+        return "LiteralToken[" +
+                "value=" + value + ']';
+    }
+
 }

--- a/common/src/main/java/revxrsal/commands/stream/token/ParameterToken.java
+++ b/common/src/main/java/revxrsal/commands/stream/token/ParameterToken.java
@@ -23,5 +23,32 @@
  */
 package revxrsal.commands.stream.token;
 
-public record ParameterToken(String name) implements Token {
+import java.util.Objects;
+
+public final class ParameterToken implements Token {
+    private final String name;
+
+    public ParameterToken(String name) {this.name = name;}
+
+    public String name() {return name;}
+
+    @Override
+    public boolean equals(Object obj) {
+        if (obj == this) return true;
+        if (obj == null || obj.getClass() != this.getClass()) return false;
+        ParameterToken that = (ParameterToken) obj;
+        return Objects.equals(this.name, that.name);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(name);
+    }
+
+    @Override
+    public String toString() {
+        return "ParameterToken[" +
+                "name=" + name + ']';
+    }
+
 }

--- a/common/src/main/java/revxrsal/commands/util/BuiltInNamingStrategies.java
+++ b/common/src/main/java/revxrsal/commands/util/BuiltInNamingStrategies.java
@@ -36,7 +36,7 @@ public final class BuiltInNamingStrategies {
         StringBuilder translation = new StringBuilder();
         for (int i = 0; i < name.length(); i++) {
             char character = name.charAt(i);
-            if (Character.isUpperCase(character) && !translation.isEmpty()) {
+            if (Character.isUpperCase(character) && translation.length() != 0) {
                 translation.append(separator);
             }
             translation.append(character);

--- a/common/src/main/java/revxrsal/commands/util/Classes.java
+++ b/common/src/main/java/revxrsal/commands/util/Classes.java
@@ -153,7 +153,8 @@ public final class Classes {
             // type is a normal class.
             return (Class<?>) type;
 
-        } else if (type instanceof ParameterizedType parameterizedType) {
+        } else if (type instanceof ParameterizedType) {
+            ParameterizedType parameterizedType = (ParameterizedType) type;
 
             // I'm not exactly sure why getRawType() returns Type instead of Class.
             // Neal isn't either but suspects some pathological case related

--- a/common/src/main/java/revxrsal/commands/util/Collections.java
+++ b/common/src/main/java/revxrsal/commands/util/Collections.java
@@ -169,6 +169,23 @@ public final class Collections {
         return new UnmodifiableIterator<>(iterator);
     }
 
+    @Contract("_ -> new")
+    @CheckReturnValue
+    @Unmodifiable
+    public static <K, V> @NotNull Map<K, V> copyMap(@NotNull Map<K, V> map) {
+        if (map instanceof LinkedHashMap) {
+            return java.util.Collections.unmodifiableMap(new LinkedHashMap<>(map));
+        }
+        return java.util.Collections.unmodifiableMap(new HashMap<>(map));
+    }
+
+    @Contract("_ -> new")
+    @CheckReturnValue
+    @Unmodifiable
+    public static <T> @NotNull List<T> copyList(@NotNull Collection<T> list) {
+        return java.util.Collections.unmodifiableList(new ArrayList<>(list));
+    }
+
     /**
      * UnmodifiableIterator, A wrapper around an iterator instance that
      * disables the remove method.

--- a/common/src/main/java/revxrsal/commands/util/CommandPaths.java
+++ b/common/src/main/java/revxrsal/commands/util/CommandPaths.java
@@ -58,7 +58,7 @@ public final class CommandPaths {
         List<String> parentSubcommandAliases = new ArrayList<>();
 
         for (Class<?> topClass : getTopClasses(container)) {
-            var annotations = AnnotationList.create(topClass)
+            AnnotationList annotations = AnnotationList.create(topClass)
                     .replaceAnnotations(topClass, function.lamp().annotationReplacers());
             Subcommand ps = annotations.get(Subcommand.class);
             if (ps != null) {

--- a/common/src/main/java/revxrsal/commands/util/InstanceCreator.java
+++ b/common/src/main/java/revxrsal/commands/util/InstanceCreator.java
@@ -45,8 +45,8 @@ public final class InstanceCreator {
     public static <T> @NotNull T create(@NotNull Class<? extends T> type) {
         if (type.isAnnotation())
             throw new IllegalArgumentException("Cannot construct annotation types");
-        if (type.isRecord())
-            throw new IllegalArgumentException("Cannot construct record types");
+//        if (type.isRecord())
+//            throw new IllegalArgumentException("Cannot construct record types");
         if (type.isArray())
             return (T) Array.newInstance(type, 0);
         if (type.isEnum())
@@ -73,7 +73,7 @@ public final class InstanceCreator {
     private static <T> @Nullable T fromNoArgConstructor(Class<? extends T> type) {
         try {
             Constructor<? extends T> constructor = type.getDeclaredConstructor();
-            constructor.trySetAccessible();
+            constructor.setAccessible(true);
             return constructor.newInstance();
         } catch (ReflectiveOperationException e) {
             return null;
@@ -89,7 +89,7 @@ public final class InstanceCreator {
                 continue;
             if (method.getParameterCount() != 0)
                 continue;
-            method.trySetAccessible();
+            method.setAccessible(true);
             try {
                 return (T) method.invoke(null);
             } catch (IllegalAccessException | InvocationTargetException e) {
@@ -99,7 +99,8 @@ public final class InstanceCreator {
         return null;
     }
 
-    private static @NotNull <T extends Enum<? extends T>> T firstEnum(Class<? extends T> type) {
+    @SuppressWarnings("rawtypes")
+    private static @NotNull <T extends Enum> T firstEnum(Class<? extends T> type) {
         T[] values = type.getEnumConstants();
         if (values.length == 0)
             throw new IllegalArgumentException("Attempted to construct an enum that has no fields");
@@ -113,7 +114,7 @@ public final class InstanceCreator {
                 continue;
             if (!isStatic(field.getModifiers()))
                 continue;
-            field.trySetAccessible();
+            field.setAccessible(true);
             try {
                 return (T) field.get(null);
             } catch (IllegalAccessException e) {

--- a/common/src/main/java/revxrsal/commands/util/StackTraceSanitizer.java
+++ b/common/src/main/java/revxrsal/commands/util/StackTraceSanitizer.java
@@ -36,6 +36,7 @@ import java.util.List;
 import java.util.function.Predicate;
 
 import static java.util.Collections.emptyList;
+import static revxrsal.commands.util.Collections.copyList;
 
 /**
  * A utility for stripping stacktrace from local paths to classes. This helps
@@ -187,7 +188,7 @@ public final class StackTraceSanitizer {
          * @return The newly created sanitizer
          */
         public StackTraceSanitizer build() {
-            return new StackTraceSanitizer(List.copyOf(filters));
+            return new StackTraceSanitizer(copyList(filters));
         }
     }
 

--- a/common/src/main/java/revxrsal/commands/util/Strings.java
+++ b/common/src/main/java/revxrsal/commands/util/Strings.java
@@ -30,6 +30,7 @@ import revxrsal.commands.annotation.list.AnnotationList;
 
 import java.util.Comparator;
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -108,6 +109,39 @@ public final class Strings {
         return builder.toString();
     }
 
-    public record StringRange(int start, int end) {}
+    public static final class StringRange {
+        private final int start;
+        private final int end;
+
+        public StringRange(int start, int end) {
+            this.start = start;
+            this.end = end;
+        }
+
+        public int start() {return start;}
+
+        public int end() {return end;}
+
+        @Override
+        public boolean equals(Object obj) {
+            if (obj == this) return true;
+            if (obj == null || obj.getClass() != this.getClass()) return false;
+            StringRange that = (StringRange) obj;
+            return this.start == that.start &&
+                    this.end == that.end;
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(start, end);
+        }
+
+        @Override
+        public String toString() {
+            return "StringRange[" +
+                    "start=" + start + ", " +
+                    "end=" + end + ']';
+        }
+    }
 
 }

--- a/examples/bukkit-plugin/src/main/java/com/example/plugin/TestPlugin.java
+++ b/examples/bukkit-plugin/src/main/java/com/example/plugin/TestPlugin.java
@@ -1,13 +1,15 @@
 package com.example.plugin;
 
 import org.bukkit.plugin.java.JavaPlugin;
+import revxrsal.commands.Lamp;
 import revxrsal.commands.bukkit.BukkitLamp;
+import revxrsal.commands.bukkit.actor.BukkitCommandActor;
 
 public final class TestPlugin extends JavaPlugin {
 
     @Override
     public void onEnable() {
-        var lamp = BukkitLamp.builder(this).build();
+        Lamp<BukkitCommandActor> lamp = BukkitLamp.builder(this).build();
         lamp.register(new GreetCommands());
     }
 }

--- a/examples/cli-app/build.gradle.kts
+++ b/examples/cli-app/build.gradle.kts
@@ -19,7 +19,3 @@ tasks.withType<JavaCompile> {
     // Preserve parameter names in the bytecode
     options.compilerArgs.add("-parameters")
 }
-
-kotlin {
-    jvmToolchain(17)
-}

--- a/examples/cli-app/src/main/java/com/example/cli/CLIApp.java
+++ b/examples/cli-app/src/main/java/com/example/cli/CLIApp.java
@@ -23,7 +23,10 @@
  */
 package com.example.cli;
 
+import revxrsal.commands.Lamp;
 import revxrsal.commands.annotation.Command;
+import revxrsal.commands.annotation.CommandPriority;
+import revxrsal.commands.annotation.Subcommand;
 import revxrsal.commands.cli.CLILamp;
 import revxrsal.commands.cli.ConsoleActor;
 
@@ -32,9 +35,10 @@ import static revxrsal.commands.cli.CLILamp.pollStdin;
 public final class CLIApp {
 
     public static void main(String[] args) {
-        var lamp = CLILamp.builder()
+        Lamp<ConsoleActor> lamp = CLILamp.builder()
                 .build();
         lamp.register(new PingCommand());
+        System.out.println(lamp.registry().commands());
         /* register all other commands here */
 
         // Call this to continuously read input from the console
@@ -47,8 +51,14 @@ public final class CLIApp {
     static class PingCommand {
 
         @Command("ping")
+        @CommandPriority.Low
         public void ping(ConsoleActor actor) {
             actor.reply("Pong");
+        }
+
+        @Command("ping help")
+        public void pingHelp(ConsoleActor actor) {
+            ping(actor);
         }
     }
 }

--- a/examples/jda-bot/src/main/java/com/example/bot/SimpleBot.java
+++ b/examples/jda-bot/src/main/java/com/example/bot/SimpleBot.java
@@ -25,7 +25,9 @@ package com.example.bot;
 
 import net.dv8tion.jda.api.JDA;
 import net.dv8tion.jda.api.JDABuilder;
+import revxrsal.commands.Lamp;
 import revxrsal.commands.jda.JDALamp;
+import revxrsal.commands.jda.actor.SlashCommandActor;
 
 import static revxrsal.commands.jda.JDAVisitors.slashCommands;
 
@@ -33,7 +35,7 @@ public class SimpleBot {
 
     public static void main(String[] args) {
         JDA jda = JDABuilder.createDefault(args[0]).build();
-        var lamp = JDALamp.builder().build();
+        Lamp<SlashCommandActor> lamp = JDALamp.builder().build();
 
         // register all our commands here
         lamp.register(new PunishmentCommands());

--- a/fabric/src/main/java/revxrsal/commands/fabric/actor/BasicActorFactory.java
+++ b/fabric/src/main/java/revxrsal/commands/fabric/actor/BasicActorFactory.java
@@ -29,21 +29,59 @@ import org.jetbrains.annotations.NotNull;
 import revxrsal.commands.Lamp;
 import revxrsal.commands.process.MessageSender;
 
+import java.util.Objects;
+
 /**
  * Default implementation of {@link ActorFactory}
  */
-record BasicActorFactory(
-        MessageSender<FabricCommandActor, Text> messageSender,
-        MessageSender<FabricCommandActor, Text> errorSender
-) implements ActorFactory<FabricCommandActor> {
+final class BasicActorFactory implements ActorFactory<FabricCommandActor> {
 
     public static final ActorFactory<FabricCommandActor> INSTANCE = new BasicActorFactory(
             FabricCommandActor::sendRawMessage,
             FabricCommandActor::sendRawError
     );
+    private final MessageSender<FabricCommandActor, Text> messageSender;
+    private final MessageSender<FabricCommandActor, Text> errorSender;
+
+    /**
+     *
+     */
+    BasicActorFactory(
+            MessageSender<FabricCommandActor, Text> messageSender,
+            MessageSender<FabricCommandActor, Text> errorSender
+    ) {
+        this.messageSender = messageSender;
+        this.errorSender = errorSender;
+    }
 
     @Override
     public @NotNull FabricCommandActor create(@NotNull ServerCommandSource sender, @NotNull Lamp<FabricCommandActor> lamp) {
         return new BasicFabricActor(sender, lamp, messageSender, errorSender);
     }
+
+    public MessageSender<FabricCommandActor, Text> messageSender() {return messageSender;}
+
+    public MessageSender<FabricCommandActor, Text> errorSender() {return errorSender;}
+
+    @Override
+    public boolean equals(Object obj) {
+        if (obj == this) return true;
+        if (obj == null || obj.getClass() != this.getClass()) return false;
+        var that = (BasicActorFactory) obj;
+        return Objects.equals(this.messageSender, that.messageSender) &&
+                Objects.equals(this.errorSender, that.errorSender);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(messageSender, errorSender);
+    }
+
+    @Override
+    public String toString() {
+        return "BasicActorFactory[" +
+                "messageSender=" + messageSender + ", " +
+                "errorSender=" + errorSender + ']';
+    }
+
 }

--- a/fabric/src/main/java/revxrsal/commands/fabric/actor/BasicFabricActor.java
+++ b/fabric/src/main/java/revxrsal/commands/fabric/actor/BasicFabricActor.java
@@ -7,16 +7,28 @@ import revxrsal.commands.Lamp;
 import revxrsal.commands.process.MessageSender;
 
 import java.nio.charset.StandardCharsets;
+import java.util.Objects;
 import java.util.UUID;
 
-record BasicFabricActor(
-        ServerCommandSource sender,
-        Lamp<FabricCommandActor> lamp,
-        MessageSender<FabricCommandActor, Text> messageSender,
-        MessageSender<FabricCommandActor, Text> errorSender
-) implements FabricCommandActor {
+final class BasicFabricActor implements FabricCommandActor {
 
     private static final UUID CONSOLE_UUID = new UUID(0, 0);
+    private final ServerCommandSource sender;
+    private final Lamp<FabricCommandActor> lamp;
+    private final MessageSender<FabricCommandActor, Text> messageSender;
+    private final MessageSender<FabricCommandActor, Text> errorSender;
+
+    BasicFabricActor(
+            ServerCommandSource sender,
+            Lamp<FabricCommandActor> lamp,
+            MessageSender<FabricCommandActor, Text> messageSender,
+            MessageSender<FabricCommandActor, Text> errorSender
+    ) {
+        this.sender = sender;
+        this.lamp = lamp;
+        this.messageSender = messageSender;
+        this.errorSender = errorSender;
+    }
 
     @Override public @NotNull ServerCommandSource source() {
         return sender;
@@ -42,4 +54,36 @@ record BasicFabricActor(
     @Override public Lamp<FabricCommandActor> lamp() {
         return lamp;
     }
+
+    public ServerCommandSource sender() {return sender;}
+
+    public MessageSender<FabricCommandActor, Text> messageSender() {return messageSender;}
+
+    public MessageSender<FabricCommandActor, Text> errorSender() {return errorSender;}
+
+    @Override
+    public boolean equals(Object obj) {
+        if (obj == this) return true;
+        if (obj == null || obj.getClass() != this.getClass()) return false;
+        var that = (BasicFabricActor) obj;
+        return Objects.equals(this.sender, that.sender) &&
+                Objects.equals(this.lamp, that.lamp) &&
+                Objects.equals(this.messageSender, that.messageSender) &&
+                Objects.equals(this.errorSender, that.errorSender);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(sender, lamp, messageSender, errorSender);
+    }
+
+    @Override
+    public String toString() {
+        return "BasicFabricActor[" +
+                "sender=" + sender + ", " +
+                "lamp=" + lamp + ", " +
+                "messageSender=" + messageSender + ", " +
+                "errorSender=" + errorSender + ']';
+    }
+
 }

--- a/fabric/src/main/java/revxrsal/commands/fabric/exception/FabricExceptionHandler.java
+++ b/fabric/src/main/java/revxrsal/commands/fabric/exception/FabricExceptionHandler.java
@@ -39,11 +39,15 @@ public class FabricExceptionHandler extends DefaultExceptionHandler<FabricComman
 
     @Override public void onInputParse(@NotNull InputParseException e, @NotNull FabricCommandActor actor) {
         switch (e.cause()) {
-            case INVALID_ESCAPE_CHARACTER ->
-                    actor.error(legacyColorize("&cInvalid input. Use &e\\\\ &cto include a backslash."));
-            case UNCLOSED_QUOTE -> actor.error(legacyColorize("&cUnclosed quote. Make sure to close all quotes."));
-            case EXPECTED_WHITESPACE ->
-                    actor.error(legacyColorize("&cExpected whitespace to end one argument, but found trailing data."));
+            case INVALID_ESCAPE_CHARACTER:
+                actor.error(legacyColorize("&cInvalid input. Use &e\\\\ &cto include a backslash."));
+                break;
+            case UNCLOSED_QUOTE:
+                actor.error(legacyColorize("&cUnclosed quote. Make sure to close all quotes."));
+                break;
+            case EXPECTED_WHITESPACE:
+                actor.error(legacyColorize("&cExpected whitespace to end one argument, but found trailing data."));
+                break;
         }
     }
 

--- a/fabric/src/main/java/revxrsal/commands/fabric/parameters/PlayerParameterType.java
+++ b/fabric/src/main/java/revxrsal/commands/fabric/parameters/PlayerParameterType.java
@@ -33,7 +33,7 @@ import revxrsal.commands.node.ExecutionContext;
 import revxrsal.commands.parameter.ParameterType;
 import revxrsal.commands.stream.MutableStringStream;
 
-import java.util.List;
+import java.util.Arrays;
 
 /**
  * A parameter type for {@link ServerPlayerEntity} types.
@@ -58,7 +58,7 @@ public class PlayerParameterType implements ParameterType<FabricCommandActor, Se
     @Override public @NotNull SuggestionProvider<FabricCommandActor> defaultSuggestions() {
         return (context) -> {
             MinecraftServer server = context.actor().source().getServer();
-            return List.of(server.getPlayerManager().getPlayerNames());
+            return Arrays.asList(server.getPlayerManager().getPlayerNames());
         };
     }
 }

--- a/fabric/src/main/java/revxrsal/commands/fabric/parameters/WorldParameterType.java
+++ b/fabric/src/main/java/revxrsal/commands/fabric/parameters/WorldParameterType.java
@@ -36,7 +36,7 @@ import revxrsal.commands.node.ExecutionContext;
 import revxrsal.commands.parameter.ParameterType;
 import revxrsal.commands.stream.MutableStringStream;
 
-import java.util.List;
+import java.util.Arrays;
 
 /**
  * A parameter type for {@link ServerPlayerEntity} types.
@@ -70,7 +70,7 @@ public class WorldParameterType implements ParameterType<FabricCommandActor, Wor
     @Override public @NotNull SuggestionProvider<FabricCommandActor> defaultSuggestions() {
         return (context) -> {
             MinecraftServer server = context.actor().source().getServer();
-            return List.of(server.getPlayerManager().getPlayerNames());
+            return Arrays.asList(server.getPlayerManager().getPlayerNames());
         };
     }
 }

--- a/internal-paper-stubs/README.md
+++ b/internal-paper-stubs/README.md
@@ -1,10 +1,14 @@
 # Paper stubs
 
 ## What is this?
-This simply contains definitions for classes and methods in the Paper API. _Only definitions_. We don't include any implementations here, and any non-abstract functions throw exceptions.
 
-This is simply to provide resolvable classes at compile-time, without having to depend on Paper's dependency directly, because it requires Java 21.
+This simply contains definitions for classes and methods in the Paper API. _Only definitions_. We don't include any
+implementations here, and any non-abstract functions throw exceptions.
 
-Even then, these stubs are not 100% equal to Paper's. They have been modified a little to avoid compiler errors and Javadoc problems.
+This is simply to provide resolvable classes at compile-time, without having to depend on Paper's dependency directly,
+because it requires Java 21.
+
+Even then, these stubs are not 100% equal to Paper's. They have been modified a little to avoid compiler errors and
+Javadoc problems.
 
 This is internal and is not intended for public use. It may change or get removed without notice.

--- a/internal-paper-stubs/build.gradle.kts
+++ b/internal-paper-stubs/build.gradle.kts
@@ -12,6 +12,5 @@ repositories {
 dependencies {
     compileOnly("org.spigotmc:spigot-api:1.16.5-R0.1-SNAPSHOT")
     compileOnly("com.mojang:brigadier:1.0.18")
+    compileOnly("net.kyori:adventure-api:4.14.0")
 }
-
-java.toolchain.languageVersion.set(JavaLanguageVersion.of(17))

--- a/internal-paper-stubs/src/main/java/com/destroystokyo/paper/event/brigadier/CommandRegisteredEvent.java
+++ b/internal-paper-stubs/src/main/java/com/destroystokyo/paper/event/brigadier/CommandRegisteredEvent.java
@@ -1,0 +1,135 @@
+package com.destroystokyo.paper.event.brigadier;
+
+import com.mojang.brigadier.tree.ArgumentCommandNode;
+import com.mojang.brigadier.tree.LiteralCommandNode;
+import com.mojang.brigadier.tree.RootCommandNode;
+import org.bukkit.command.Command;
+import org.bukkit.event.Cancellable;
+import org.bukkit.event.HandlerList;
+import org.bukkit.event.server.ServerEvent;
+import org.jetbrains.annotations.ApiStatus;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * Fired anytime the server synchronizes Bukkit commands to Brigadier.
+ *
+ * <p>Allows a plugin to control the command node structure for its commands.
+ * This is done at Plugin Enable time after commands have been registered, but may also
+ * run at a later point in the server lifetime due to plugins, a server reload, etc.</p>
+ *
+ * <p>This is a draft/experimental API and is subject to change.</p>
+ */
+@ApiStatus.Experimental
+public class CommandRegisteredEvent<S> extends ServerEvent implements Cancellable {
+
+    @NotNull
+    public static HandlerList getHandlerList() {
+        throw new UnsupportedOperationException("Stub");
+    }
+
+    /**
+     * Gets the command label of the {@link Command} being registered.
+     *
+     * @return the command label
+     */
+    public String getCommandLabel() {
+        throw new UnsupportedOperationException("Stub");
+    }
+
+    /**
+     * Gets the {@link Command} being registered.
+     *
+     * @return the {@link Command}
+     */
+    public Command getCommand() {
+        throw new UnsupportedOperationException("Stub");
+    }
+
+    /**
+     * Gets the {@link RootCommandNode} which is being registered to.
+     *
+     * @return the {@link RootCommandNode}
+     */
+    public RootCommandNode<S> getRoot() {
+        throw new UnsupportedOperationException("Stub");
+    }
+
+    /**
+     * Gets the Bukkit APIs default arguments node (greedy string), for if
+     * you wish to reuse it.
+     *
+     * @return default arguments node
+     */
+    public ArgumentCommandNode<S, String> getDefaultArgs() {
+        throw new UnsupportedOperationException("Stub");
+    }
+
+    /**
+     * Gets the {@link LiteralCommandNode} to be registered for the {@link Command}.
+     *
+     * @return the {@link LiteralCommandNode}
+     */
+    public LiteralCommandNode<S> getLiteral() {
+        throw new UnsupportedOperationException("Stub");
+    }
+
+    /**
+     * Sets the {@link LiteralCommandNode} used to register this command. The default literal is mutable, so
+     * this is primarily if you want to completely replace the object.
+     *
+     * @param literal new node
+     */
+    public void setLiteral(LiteralCommandNode<S> literal) {
+        throw new UnsupportedOperationException("Stub");
+    }
+
+    /**
+     * Gets whether this command should is treated as "raw".
+     *
+     * @return whether this command is treated as "raw"
+     * @see #setRawCommand(boolean)
+     */
+    public boolean isRawCommand() {
+        throw new UnsupportedOperationException("Stub");
+    }
+
+    /**
+     * Sets whether this command should be treated as "raw".
+     *
+     * <p>A "raw" command will only use the node provided by this event for
+     * sending the command tree to the client. For execution purposes, the default
+     * greedy string execution of a standard Bukkit {@link Command} is used.</p>
+     *
+     * <p>On older versions of Paper, this was the default and only behavior of this
+     * event.</p>
+     *
+     * @param rawCommand whether this command should be treated as "raw"
+     */
+    public void setRawCommand(final boolean rawCommand) {
+        throw new UnsupportedOperationException("Stub");
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public boolean isCancelled() {
+        throw new UnsupportedOperationException("Stub");
+    }
+
+    /**
+     * Cancels registering this command to Brigadier, but will remain in Bukkit Command Map. Can be used to hide a
+     * command from all players.
+     * <p>
+     * {@inheritDoc}
+     */
+    @Override
+    public void setCancelled(boolean cancel) {
+        throw new UnsupportedOperationException("Stub");
+    }
+
+    @NotNull
+    public HandlerList getHandlers() {
+        throw new UnsupportedOperationException("Stub");
+    }
+}

--- a/internal-paper-stubs/src/main/java/io/papermc/paper/command/brigadier/BasicCommand.java
+++ b/internal-paper-stubs/src/main/java/io/papermc/paper/command/brigadier/BasicCommand.java
@@ -1,11 +1,12 @@
 package io.papermc.paper.command.brigadier;
 
-import java.util.Collection;
-import java.util.Collections;
 import org.bukkit.command.CommandSender;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+
+import java.util.Collection;
+import java.util.Collections;
 
 /**
  * Implementing this interface allows for easily creating "Bukkit-style" {@code String[] args} commands.
@@ -19,7 +20,7 @@ public interface BasicCommand {
      * Executes the command with the given {@link CommandSourceStack} and arguments.
      *
      * @param commandSourceStack the commandSourceStack of the command
-     * @param args the arguments of the command ignoring repeated spaces
+     * @param args               the arguments of the command ignoring repeated spaces
      */
     @ApiStatus.OverrideOnly
     void execute(@NotNull CommandSourceStack commandSourceStack, @NotNull String[] args);
@@ -28,7 +29,7 @@ public interface BasicCommand {
      * Suggests possible completions for the given command {@link CommandSourceStack} and arguments.
      *
      * @param commandSourceStack the commandSourceStack of the command
-     * @param args the arguments of the command including repeated spaces
+     * @param args               the arguments of the command including repeated spaces
      * @return a collection of suggestions
      */
     @ApiStatus.OverrideOnly

--- a/internal-paper-stubs/src/main/java/io/papermc/paper/command/brigadier/Commands.java
+++ b/internal-paper-stubs/src/main/java/io/papermc/paper/command/brigadier/Commands.java
@@ -39,7 +39,7 @@ import java.util.Set;
  *                     })
  *                     .build(),
  *                 "some bukkit help description string",
- *                 List.of("an-alias")
+ *                 Arrays.asList("an-alias")
  *             );
  *         });
  *     }
@@ -149,7 +149,7 @@ public interface Commands extends Registrar {
      *   <li>The main command/namespaced label will override already existing commands</li>
      * </ul>
      *
-     * @param node the built literal command node
+     * @param node    the built literal command node
      * @param aliases a collection of aliases to register the literal node's command to
      * @return successfully registered root command labels (including aliases and namespaced variants)
      */
@@ -171,7 +171,8 @@ public interface Commands extends Registrar {
      * @param aliases     a collection of aliases to register the literal node's command to
      * @return successfully registered root command labels (including aliases and namespaced variants)
      */
-    @Unmodifiable @NotNull Set<String> register(@NotNull LiteralCommandNode<CommandSourceStack> node, @Nullable String description, @NotNull Collection<String> aliases);
+    @Unmodifiable
+    @NotNull Set<String> register(@NotNull LiteralCommandNode<CommandSourceStack> node, @Nullable String description, @NotNull Collection<String> aliases);
 
     /**
      * Registers a command for a plugin.
@@ -188,7 +189,8 @@ public interface Commands extends Registrar {
      * @param aliases     a collection of aliases to register the literal node's command to
      * @return successfully registered root command labels (including aliases and namespaced variants)
      */
-    @Unmodifiable @NotNull Set<String> register(@NotNull PluginMeta pluginMeta, @NotNull LiteralCommandNode<CommandSourceStack> node, @Nullable String description, @NotNull Collection<String> aliases);
+    @Unmodifiable
+    @NotNull Set<String> register(@NotNull PluginMeta pluginMeta, @NotNull LiteralCommandNode<CommandSourceStack> node, @Nullable String description, @NotNull Collection<String> aliases);
 
     /**
      * Registers a command under the same logic as {@link Commands#register(LiteralCommandNode, String, Collection)}.
@@ -234,7 +236,8 @@ public interface Commands extends Registrar {
      * @param basicCommand the basic command instance to register
      * @return successfully registered root command labels (including aliases and namespaced variants)
      */
-    @Unmodifiable @NotNull Set<String> register(@NotNull String label, @Nullable String description, @NotNull Collection<String> aliases, @NotNull BasicCommand basicCommand);
+    @Unmodifiable
+    @NotNull Set<String> register(@NotNull String label, @Nullable String description, @NotNull Collection<String> aliases, @NotNull BasicCommand basicCommand);
 
     /**
      * Registers a command under the same logic as {@link Commands#register(PluginMeta, LiteralCommandNode, String, Collection)}.
@@ -246,5 +249,6 @@ public interface Commands extends Registrar {
      * @param basicCommand the basic command instance to register
      * @return successfully registered root command labels (including aliases and namespaced variants)
      */
-    @Unmodifiable @NotNull Set<String> register(@NotNull PluginMeta pluginMeta, @NotNull String label, @Nullable String description, @NotNull Collection<String> aliases, @NotNull BasicCommand basicCommand);
+    @Unmodifiable
+    @NotNull Set<String> register(@NotNull PluginMeta pluginMeta, @NotNull String label, @Nullable String description, @NotNull Collection<String> aliases, @NotNull BasicCommand basicCommand);
 }

--- a/internal-paper-stubs/src/main/java/io/papermc/paper/plugin/configuration/PluginMeta.java
+++ b/internal-paper-stubs/src/main/java/io/papermc/paper/plugin/configuration/PluginMeta.java
@@ -81,7 +81,7 @@ public interface PluginMeta {
      * plugin.
      *
      * @return the specific overwrite of the logger prefix as defined by the plugin. If the plugin did not define a
-     *     custom logger prefix, this method will return null
+     * custom logger prefix, this method will return null
      */
     @Nullable
     String getLoggerPrefix();

--- a/internal-paper-stubs/src/main/java/io/papermc/paper/plugin/lifecycle/event/LifecycleEvent.java
+++ b/internal-paper-stubs/src/main/java/io/papermc/paper/plugin/lifecycle/event/LifecycleEvent.java
@@ -9,6 +9,7 @@ import org.jetbrains.annotations.ApiStatus;
  * Lifecycle events are generally fired when the older
  * event system is not available, like during early
  * server initialization.
+ *
  * @see LifecycleEvents
  */
 @ApiStatus.Experimental

--- a/internal-paper-stubs/src/main/java/io/papermc/paper/plugin/lifecycle/event/handler/configuration/LifecycleEventHandlerConfiguration.java
+++ b/internal-paper-stubs/src/main/java/io/papermc/paper/plugin/lifecycle/event/handler/configuration/LifecycleEventHandlerConfiguration.java
@@ -1,6 +1,5 @@
 package io.papermc.paper.plugin.lifecycle.event.handler.configuration;
 
-import io.papermc.paper.plugin.lifecycle.event.LifecycleEventOwner;
 import io.papermc.paper.plugin.lifecycle.event.handler.LifecycleEventHandler;
 import org.jetbrains.annotations.ApiStatus;
 

--- a/internal-paper-stubs/src/main/java/io/papermc/paper/plugin/lifecycle/event/handler/configuration/MonitorLifecycleEventHandlerConfiguration.java
+++ b/internal-paper-stubs/src/main/java/io/papermc/paper/plugin/lifecycle/event/handler/configuration/MonitorLifecycleEventHandlerConfiguration.java
@@ -1,6 +1,5 @@
 package io.papermc.paper.plugin.lifecycle.event.handler.configuration;
 
-import io.papermc.paper.plugin.lifecycle.event.LifecycleEventOwner;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.Contract;
 

--- a/internal-paper-stubs/src/main/java/io/papermc/paper/plugin/lifecycle/event/handler/configuration/PrioritizedLifecycleEventHandlerConfiguration.java
+++ b/internal-paper-stubs/src/main/java/io/papermc/paper/plugin/lifecycle/event/handler/configuration/PrioritizedLifecycleEventHandlerConfiguration.java
@@ -1,6 +1,5 @@
 package io.papermc.paper.plugin.lifecycle.event.handler.configuration;
 
-import io.papermc.paper.plugin.lifecycle.event.LifecycleEventOwner;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.Contract;
 

--- a/internal-paper-stubs/src/main/java/io/papermc/paper/plugin/lifecycle/event/types/LifecycleEventType.java
+++ b/internal-paper-stubs/src/main/java/io/papermc/paper/plugin/lifecycle/event/types/LifecycleEventType.java
@@ -2,7 +2,6 @@ package io.papermc.paper.plugin.lifecycle.event.types;
 
 import io.papermc.paper.plugin.lifecycle.event.LifecycleEvent;
 import io.papermc.paper.plugin.lifecycle.event.LifecycleEventManager;
-import io.papermc.paper.plugin.lifecycle.event.LifecycleEventOwner;
 import io.papermc.paper.plugin.lifecycle.event.handler.LifecycleEventHandler;
 import io.papermc.paper.plugin.lifecycle.event.handler.configuration.LifecycleEventHandlerConfiguration;
 import io.papermc.paper.plugin.lifecycle.event.handler.configuration.MonitorLifecycleEventHandlerConfiguration;

--- a/internal-paper-stubs/src/main/java/io/papermc/paper/plugin/lifecycle/event/types/LifecycleEvents.java
+++ b/internal-paper-stubs/src/main/java/io/papermc/paper/plugin/lifecycle/event/types/LifecycleEvents.java
@@ -24,12 +24,12 @@ public final class LifecycleEvents {
      */
     public static final LifecycleEventType.Prioritizable<LifecycleEventOwner, ReloadableRegistrarEvent<Commands>> COMMANDS = prioritized("commands", LifecycleEventOwner.class);
 
-    @ApiStatus.Internal
-    private static <O, E extends LifecycleEvent> LifecycleEventType.Prioritizable<O, E> prioritized(final String name, final Class<? extends O> ownerType) {
-        throw new UnsupportedOperationException("Stub");
+    private LifecycleEvents() {
     }
     //</editor-fold>
 
-    private LifecycleEvents() {
+    @ApiStatus.Internal
+    private static <O, E extends LifecycleEvent> LifecycleEventType.Prioritizable<O, E> prioritized(final String name, final Class<? extends O> ownerType) {
+        throw new UnsupportedOperationException("Stub");
     }
 }

--- a/internal-paper-stubs/src/main/java/org/bukkit/event/command/UnknownCommandEvent.java
+++ b/internal-paper-stubs/src/main/java/org/bukkit/event/command/UnknownCommandEvent.java
@@ -1,0 +1,93 @@
+package org.bukkit.event.command;
+
+import net.kyori.adventure.text.Component;
+import org.bukkit.command.CommandSender;
+import org.bukkit.event.Event;
+import org.bukkit.event.HandlerList;
+import org.jetbrains.annotations.Contract;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+public class UnknownCommandEvent extends Event {
+
+    @NotNull
+    public static HandlerList getHandlerList() {
+        throw new UnsupportedOperationException("Stub");
+    }
+
+    /**
+     * Gets the CommandSender or ConsoleCommandSender
+     * <p>
+     *
+     * @return Sender of the command
+     */
+    @NotNull
+    public CommandSender getSender() {
+        throw new UnsupportedOperationException("Stub");
+    }
+
+    /**
+     * Gets the command that was send
+     * <p>
+     *
+     * @return Command sent
+     */
+    @NotNull
+    public String getCommandLine() {
+        throw new UnsupportedOperationException("Stub");
+    }
+
+    /**
+     * Gets message that will be returned
+     * <p>
+     *
+     * @return Unknown command message
+     * @deprecated use {@link #message()}
+     */
+    @Nullable
+    @Deprecated
+    public String getMessage() {
+        throw new UnsupportedOperationException("Stub");
+    }
+
+    /**
+     * Sets message that will be returned
+     * <p>
+     * Set to null to avoid any message being sent
+     *
+     * @param message the message to be returned, or null
+     * @deprecated use {@link #message(Component)}
+     */
+    @Deprecated
+    public void setMessage(@Nullable String message) {
+        throw new UnsupportedOperationException("Stub");
+    }
+
+    /**
+     * Gets message that will be returned
+     * <p>
+     *
+     * @return Unknown command message
+     */
+    @Nullable
+    @Contract(pure = true)
+    public Component message() {
+        throw new UnsupportedOperationException("Stub");
+    }
+
+    /**
+     * Sets message that will be returned
+     * <p>
+     * Set to null to avoid any message being sent
+     *
+     * @param message the message to be returned, or null
+     */
+    public void message(@Nullable Component message) {
+        throw new UnsupportedOperationException("Stub");
+    }
+
+    @NotNull
+    public HandlerList getHandlers() {
+        throw new UnsupportedOperationException("Stub");
+    }
+}

--- a/jda/src/main/java/revxrsal/commands/jda/JDAUtils.java
+++ b/jda/src/main/java/revxrsal/commands/jda/JDAUtils.java
@@ -130,44 +130,39 @@ public final class JDAUtils {
             @NotNull ParameterNode<A, ?> parameter
     ) {
         switch (option.getType()) {
-            case STRING -> {
+            case STRING:
                 return option.getAsString();
-            }
-            case INTEGER -> {
+            case INTEGER:
                 return safeIntegerCast(option.getAsInt(), parameter.type());
-            }
-            case NUMBER -> {
+            case NUMBER:
                 return safeDoubleCast(option.getAsInt(), parameter.type());
-            }
-            case BOOLEAN -> {
+            case BOOLEAN:
                 return option.getAsBoolean();
-            }
-            case USER -> {
+            case USER:
                 if (parameter.type() == Member.class) {
                     Member asMember = option.getAsMember();
-                    if (asMember == null)
+                    if (asMember == null) {
                         throw new MemberNotInGuildException(option.getAsUser());
+                    }
                     return asMember;
                 }
                 return option.getAsUser();
-            }
-            case CHANNEL -> {
-                if (option.getChannelType().getInterface().isAssignableFrom(parameter.type()))
+            case CHANNEL:
+                if (option.getChannelType().getInterface().isAssignableFrom(parameter.type())) {
                     return option.getAsChannel();
+                }
                 throw new WrongChannelTypeException(option.getAsChannel(), parameter.type());
-            }
-            case ROLE -> {
+            case ROLE:
                 return option.getAsRole();
-            }
-            case MENTIONABLE -> {
+            case MENTIONABLE:
                 return option.getAsMentionable();
-            }
-            case ATTACHMENT -> {
+            case ATTACHMENT:
                 return option.getAsAttachment();
-            }
+            default:
+                throw new IllegalArgumentException("Don't know how to fetch a value from Option: " + option + " for parameter " + parameter.name() + " of type " + parameter.type());
         }
-        throw new IllegalArgumentException("Don't know how to fetch a value from Option: " + option + " for parameter " + parameter.name() + " of type " + parameter.type());
     }
+
 
     private static @NotNull Object safeIntegerCast(int value, Class<?> type) {
         if (type == int.class)

--- a/jda/src/main/java/revxrsal/commands/jda/slash/JDAParser.java
+++ b/jda/src/main/java/revxrsal/commands/jda/slash/JDAParser.java
@@ -111,7 +111,8 @@ public final class JDAParser<A extends SlashCommandActor> {
                 if (!canUseLiterals)
                     throw new IllegalArgumentException("You can only have 3 consecutive literals in slash commands!");
             }
-            if (node instanceof ParameterNode<A, ?> parameter) {
+            if (node instanceof ParameterNode) {
+                ParameterNode<A, ?> parameter = (ParameterNode<A, ?>) node;
                 if (parameter.isSwitch())
                     throw new IllegalArgumentException("Switches are not supported in JDA slash commands.");
                 if (parameter.isFlag())

--- a/jda/src/main/java/revxrsal/commands/jda/slash/JDASlashListener.java
+++ b/jda/src/main/java/revxrsal/commands/jda/slash/JDASlashListener.java
@@ -42,6 +42,7 @@ import revxrsal.commands.node.ParameterNode;
 import revxrsal.commands.stream.MutableStringStream;
 import revxrsal.commands.stream.StringStream;
 
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -63,7 +64,8 @@ public final class JDASlashListener<A extends SlashCommandActor> implements Even
     private void onSlashCommandInteraction(@NotNull SlashCommandInteractionEvent event) {
         A actor = actorFactory.create(event, lamp);
         String fullPath = event.getFullCommandName();
-        ExecutableCommand<A> command = findCommand(lamp, fullPath, event.getOptions()).orElseThrow();
+        ExecutableCommand<A> command = findCommand(lamp, fullPath, event.getOptions())
+                .orElseThrow(() -> new IllegalArgumentException("No such command"));
         ExecutionContext<A> context = readArgumentsIntoContext(
                 actor,
                 command,
@@ -90,7 +92,7 @@ public final class JDASlashListener<A extends SlashCommandActor> implements Even
                 true
         );
         ParameterNode<A, ?> node = command.parameter(event.getFocusedOption().getName());
-        var suggestions = node.suggestions().getSuggestions(context);
+        Collection<String> suggestions = node.suggestions().getSuggestions(context);
 
         List<Command.Choice> choices = toChoices(suggestions, event.getFocusedOption().getType());
         event.replyChoices(choices).queue();
@@ -144,9 +146,11 @@ public final class JDASlashListener<A extends SlashCommandActor> implements Even
     }
 
     @Override public void onEvent(@NotNull GenericEvent event) {
-        if (event instanceof SlashCommandInteractionEvent slash) {
+        if (event instanceof SlashCommandInteractionEvent) {
+            SlashCommandInteractionEvent slash = (SlashCommandInteractionEvent) event;
             onSlashCommandInteraction(slash);
-        } else if (event instanceof CommandAutoCompleteInteractionEvent complete) {
+        } else if (event instanceof CommandAutoCompleteInteractionEvent) {
+            CommandAutoCompleteInteractionEvent complete = (CommandAutoCompleteInteractionEvent) event;
             onCommandAutoCompleteInteraction(complete);
         }
     }

--- a/minestom/src/main/java/revxrsal/commands/minestom/actor/BasicActorFactory.java
+++ b/minestom/src/main/java/revxrsal/commands/minestom/actor/BasicActorFactory.java
@@ -29,21 +29,59 @@ import org.jetbrains.annotations.NotNull;
 import revxrsal.commands.Lamp;
 import revxrsal.commands.process.MessageSender;
 
+import java.util.Objects;
+
 /**
  * Default implementation of {@link ActorFactory}
  */
-record BasicActorFactory(
-        MessageSender<MinestomCommandActor, ComponentLike> messageSender,
-        MessageSender<MinestomCommandActor, ComponentLike> errorSender
-) implements ActorFactory<MinestomCommandActor> {
+final class BasicActorFactory implements ActorFactory<MinestomCommandActor> {
 
     public static final ActorFactory<MinestomCommandActor> INSTANCE = new BasicActorFactory(
             MinestomCommandActor::sendRawMessage,
             MinestomCommandActor::sendRawError
     );
+    private final MessageSender<MinestomCommandActor, ComponentLike> messageSender;
+    private final MessageSender<MinestomCommandActor, ComponentLike> errorSender;
+
+    /**
+     *
+     */
+    BasicActorFactory(
+            MessageSender<MinestomCommandActor, ComponentLike> messageSender,
+            MessageSender<MinestomCommandActor, ComponentLike> errorSender
+    ) {
+        this.messageSender = messageSender;
+        this.errorSender = errorSender;
+    }
 
     @Override
     public @NotNull MinestomCommandActor create(@NotNull CommandSender sender, @NotNull Lamp<MinestomCommandActor> lamp) {
         return new BasicMinestomActor(sender, lamp, messageSender, errorSender);
     }
+
+    public MessageSender<MinestomCommandActor, ComponentLike> messageSender() {return messageSender;}
+
+    public MessageSender<MinestomCommandActor, ComponentLike> errorSender() {return errorSender;}
+
+    @Override
+    public boolean equals(Object obj) {
+        if (obj == this) return true;
+        if (obj == null || obj.getClass() != this.getClass()) return false;
+        var that = (BasicActorFactory) obj;
+        return Objects.equals(this.messageSender, that.messageSender) &&
+                Objects.equals(this.errorSender, that.errorSender);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(messageSender, errorSender);
+    }
+
+    @Override
+    public String toString() {
+        return "BasicActorFactory[" +
+                "messageSender=" + messageSender + ", " +
+                "errorSender=" + errorSender + ']';
+    }
+
 }

--- a/minestom/src/main/java/revxrsal/commands/minestom/actor/BasicMinestomActor.java
+++ b/minestom/src/main/java/revxrsal/commands/minestom/actor/BasicMinestomActor.java
@@ -8,14 +8,26 @@ import revxrsal.commands.Lamp;
 import revxrsal.commands.process.MessageSender;
 
 import java.nio.charset.StandardCharsets;
+import java.util.Objects;
 import java.util.UUID;
 
-record BasicMinestomActor(
-        CommandSender sender,
-        Lamp<MinestomCommandActor> lamp,
-        MessageSender<MinestomCommandActor, ComponentLike> messageSender,
-        MessageSender<MinestomCommandActor, ComponentLike> errorSender
-) implements MinestomCommandActor {
+final class BasicMinestomActor implements MinestomCommandActor {
+    private final CommandSender sender;
+    private final Lamp<MinestomCommandActor> lamp;
+    private final MessageSender<MinestomCommandActor, ComponentLike> messageSender;
+    private final MessageSender<MinestomCommandActor, ComponentLike> errorSender;
+
+    BasicMinestomActor(
+            CommandSender sender,
+            Lamp<MinestomCommandActor> lamp,
+            MessageSender<MinestomCommandActor, ComponentLike> messageSender,
+            MessageSender<MinestomCommandActor, ComponentLike> errorSender
+    ) {
+        this.sender = sender;
+        this.lamp = lamp;
+        this.messageSender = messageSender;
+        this.errorSender = errorSender;
+    }
 
     @Override public @NotNull CommandSender sender() {
         return sender;
@@ -39,4 +51,34 @@ record BasicMinestomActor(
     @Override public Lamp<MinestomCommandActor> lamp() {
         return lamp;
     }
+
+    public MessageSender<MinestomCommandActor, ComponentLike> messageSender() {return messageSender;}
+
+    public MessageSender<MinestomCommandActor, ComponentLike> errorSender() {return errorSender;}
+
+    @Override
+    public boolean equals(Object obj) {
+        if (obj == this) return true;
+        if (obj == null || obj.getClass() != this.getClass()) return false;
+        var that = (BasicMinestomActor) obj;
+        return Objects.equals(this.sender, that.sender) &&
+                Objects.equals(this.lamp, that.lamp) &&
+                Objects.equals(this.messageSender, that.messageSender) &&
+                Objects.equals(this.errorSender, that.errorSender);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(sender, lamp, messageSender, errorSender);
+    }
+
+    @Override
+    public String toString() {
+        return "BasicMinestomActor[" +
+                "sender=" + sender + ", " +
+                "lamp=" + lamp + ", " +
+                "messageSender=" + messageSender + ", " +
+                "errorSender=" + errorSender + ']';
+    }
+
 }

--- a/minestom/src/main/java/revxrsal/commands/minestom/argument/ArgumentTypes.java
+++ b/minestom/src/main/java/revxrsal/commands/minestom/argument/ArgumentTypes.java
@@ -31,10 +31,7 @@ import revxrsal.commands.autocomplete.SuggestionProviders;
 import revxrsal.commands.command.CommandActor;
 import revxrsal.commands.node.ParameterNode;
 
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.List;
-import java.util.Optional;
+import java.util.*;
 import java.util.function.Function;
 
 import static revxrsal.commands.util.Preconditions.notNull;
@@ -52,7 +49,7 @@ public final class ArgumentTypes<A extends CommandActor> {
      * <p>
      * These also will not be included in {@link #toBuilder()}.
      */
-    private static final List<ArgumentTypeFactory<?>> DEFAULT_FACTORIES = List.of(
+    private static final List<ArgumentTypeFactory<?>> DEFAULT_FACTORIES = Arrays.asList(
             DefaultTypeFactories.LONG,
             DefaultTypeFactories.INTEGER,
             DefaultTypeFactories.SHORT,

--- a/minestom/src/main/java/revxrsal/commands/minestom/exception/MinestomExceptionHandler.java
+++ b/minestom/src/main/java/revxrsal/commands/minestom/exception/MinestomExceptionHandler.java
@@ -45,11 +45,15 @@ public class MinestomExceptionHandler extends DefaultExceptionHandler<MinestomCo
 
     @Override public void onInputParse(@NotNull InputParseException e, @NotNull MinestomCommandActor actor) {
         switch (e.cause()) {
-            case INVALID_ESCAPE_CHARACTER ->
-                    actor.error(legacyColorize("&cInvalid input. Use &e\\\\ &cto include a backslash."));
-            case UNCLOSED_QUOTE -> actor.error(legacyColorize("&cUnclosed quote. Make sure to close all quotes."));
-            case EXPECTED_WHITESPACE ->
-                    actor.error(legacyColorize("&cExpected whitespace to end one argument, but found trailing data."));
+            case INVALID_ESCAPE_CHARACTER:
+                actor.error(legacyColorize("&cInvalid input. Use &e\\\\ &cto include a backslash."));
+                break;
+            case UNCLOSED_QUOTE:
+                actor.error(legacyColorize("&cUnclosed quote. Make sure to close all quotes."));
+                break;
+            case EXPECTED_WHITESPACE:
+                actor.error(legacyColorize("&cExpected whitespace to end one argument, but found trailing data."));
+                break;
         }
     }
 

--- a/minestom/src/main/java/revxrsal/commands/minestom/hooks/ArgumentColl.java
+++ b/minestom/src/main/java/revxrsal/commands/minestom/hooks/ArgumentColl.java
@@ -27,6 +27,8 @@ import net.minestom.server.command.builder.arguments.Argument;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 
 final class ArgumentColl {
@@ -34,11 +36,11 @@ final class ArgumentColl {
     private final List<Argument<?>> arguments;
 
     public ArgumentColl(Argument<?> first, Argument<?> second) {
-        this.arguments = List.of(first, second);
+        this.arguments = Arrays.asList(first, second);
     }
 
     public ArgumentColl(Argument<?> argument) {
-        this.arguments = List.of(argument);
+        this.arguments = Collections.singletonList(argument);
     }
 
     public List<Argument<?>> arguments() {

--- a/minestom/src/main/java/revxrsal/commands/minestom/hooks/MinestomCommandHooks.java
+++ b/minestom/src/main/java/revxrsal/commands/minestom/hooks/MinestomCommandHooks.java
@@ -107,7 +107,8 @@ public final class MinestomCommandHooks<A extends MinestomCommandActor> implemen
 
                 if (node.isLiteral())
                     arguments.add(toArgument(node));
-                else if (node instanceof ParameterNode<A, ?> parameter) {
+                else if (node instanceof ParameterNode<A, ?>) {
+                    ParameterNode<A, ?> parameter = (ParameterNode<A, ?>) node;
                     if (parameter.isSwitch()) {
                         // add the required
                         minestomCommand.addSyntax(generateAction(command), arguments.toArray(Argument[]::new));
@@ -220,9 +221,11 @@ public final class MinestomCommandHooks<A extends MinestomCommandActor> implemen
             A actor = actorFactory.create(sender, node.lamp());
             StringStream input = StringStream.create(exception.getInput());
             ExecutionContext<A> context = ExecutionContext.create(node.command(), actor, input);
-            if (node instanceof LiteralNode<A> literal) {
+            if (node instanceof LiteralNode<A>) {
+                LiteralNode<A> literal = (LiteralNode<A>) node;
                 node.lamp().handleException(exception, ErrorContext.parsingLiteral(context, literal));
-            } else if (node instanceof ParameterNode<A, ?> parameter) {
+            } else if (node instanceof ParameterNode<A, ?>) {
+                ParameterNode<A, ?> parameter = (ParameterNode<A, ?>) node;
                 node.lamp().handleException(exception, ErrorContext.parsingParameter(context, parameter, input));
             }
         };

--- a/sponge/src/main/java/revxrsal/commands/sponge/actor/BasicActorFactory.java
+++ b/sponge/src/main/java/revxrsal/commands/sponge/actor/BasicActorFactory.java
@@ -29,22 +29,60 @@ import org.spongepowered.api.command.CommandCause;
 import revxrsal.commands.Lamp;
 import revxrsal.commands.process.MessageSender;
 
+import java.util.Objects;
+
 /**
  * Default implementation of {@link ActorFactory}
  */
-record BasicActorFactory(
-        MessageSender<SpongeCommandActor, ComponentLike> messageSender,
-        MessageSender<SpongeCommandActor, ComponentLike> errorSender
-) implements ActorFactory<SpongeCommandActor> {
+final class BasicActorFactory implements ActorFactory<SpongeCommandActor> {
 
     public static final ActorFactory<SpongeCommandActor> INSTANCE = new BasicActorFactory(
             SpongeCommandActor::sendRawMessage,
             SpongeCommandActor::sendRawError
     );
+    private final MessageSender<SpongeCommandActor, ComponentLike> messageSender;
+    private final MessageSender<SpongeCommandActor, ComponentLike> errorSender;
+
+    /**
+     *
+     */
+    BasicActorFactory(
+            MessageSender<SpongeCommandActor, ComponentLike> messageSender,
+            MessageSender<SpongeCommandActor, ComponentLike> errorSender
+    ) {
+        this.messageSender = messageSender;
+        this.errorSender = errorSender;
+    }
 
 
     @Override
     public @NotNull SpongeCommandActor create(@NotNull CommandCause sender, @NotNull Lamp<SpongeCommandActor> lamp) {
         return new BasicSpongeActor(sender, lamp, messageSender, errorSender);
     }
+
+    public MessageSender<SpongeCommandActor, ComponentLike> messageSender() {return messageSender;}
+
+    public MessageSender<SpongeCommandActor, ComponentLike> errorSender() {return errorSender;}
+
+    @Override
+    public boolean equals(Object obj) {
+        if (obj == this) return true;
+        if (obj == null || obj.getClass() != this.getClass()) return false;
+        BasicActorFactory that = (BasicActorFactory) obj;
+        return Objects.equals(this.messageSender, that.messageSender) &&
+                Objects.equals(this.errorSender, that.errorSender);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(messageSender, errorSender);
+    }
+
+    @Override
+    public String toString() {
+        return "BasicActorFactory[" +
+                "messageSender=" + messageSender + ", " +
+                "errorSender=" + errorSender + ']';
+    }
+
 }

--- a/sponge/src/main/java/revxrsal/commands/sponge/actor/BasicSpongeActor.java
+++ b/sponge/src/main/java/revxrsal/commands/sponge/actor/BasicSpongeActor.java
@@ -8,16 +8,28 @@ import revxrsal.commands.Lamp;
 import revxrsal.commands.process.MessageSender;
 
 import java.nio.charset.StandardCharsets;
+import java.util.Objects;
 import java.util.UUID;
 
-record BasicSpongeActor(
-        CommandCause sender,
-        Lamp<SpongeCommandActor> lamp,
-        MessageSender<SpongeCommandActor, net.kyori.adventure.text.ComponentLike> messageSender,
-        MessageSender<SpongeCommandActor, ComponentLike> errorSender
-) implements SpongeCommandActor {
+final class BasicSpongeActor implements SpongeCommandActor {
 
     private static final UUID CONSOLE_UUID = new UUID(0, 0);
+    private final CommandCause sender;
+    private final Lamp<SpongeCommandActor> lamp;
+    private final MessageSender<SpongeCommandActor, ComponentLike> messageSender;
+    private final MessageSender<SpongeCommandActor, ComponentLike> errorSender;
+
+    BasicSpongeActor(
+            CommandCause sender,
+            Lamp<SpongeCommandActor> lamp,
+            MessageSender<SpongeCommandActor, ComponentLike> messageSender,
+            MessageSender<SpongeCommandActor, ComponentLike> errorSender
+    ) {
+        this.sender = sender;
+        this.lamp = lamp;
+        this.messageSender = messageSender;
+        this.errorSender = errorSender;
+    }
 
     @Override public @NotNull CommandCause cause() {
         return sender;
@@ -43,4 +55,36 @@ record BasicSpongeActor(
     @Override public Lamp<SpongeCommandActor> lamp() {
         return lamp;
     }
+
+    public CommandCause sender() {return sender;}
+
+    public MessageSender<SpongeCommandActor, ComponentLike> messageSender() {return messageSender;}
+
+    public MessageSender<SpongeCommandActor, ComponentLike> errorSender() {return errorSender;}
+
+    @Override
+    public boolean equals(Object obj) {
+        if (obj == this) return true;
+        if (obj == null || obj.getClass() != this.getClass()) return false;
+        BasicSpongeActor that = (BasicSpongeActor) obj;
+        return Objects.equals(this.sender, that.sender) &&
+                Objects.equals(this.lamp, that.lamp) &&
+                Objects.equals(this.messageSender, that.messageSender) &&
+                Objects.equals(this.errorSender, that.errorSender);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(sender, lamp, messageSender, errorSender);
+    }
+
+    @Override
+    public String toString() {
+        return "BasicSpongeActor[" +
+                "sender=" + sender + ", " +
+                "lamp=" + lamp + ", " +
+                "messageSender=" + messageSender + ", " +
+                "errorSender=" + errorSender + ']';
+    }
+
 }

--- a/sponge/src/main/java/revxrsal/commands/sponge/actor/SpongeCommandActor.java
+++ b/sponge/src/main/java/revxrsal/commands/sponge/actor/SpongeCommandActor.java
@@ -207,7 +207,8 @@ public interface SpongeCommandActor extends CommandActor {
      */
     @Override @NotNull
     default String name() {
-        if (subject() instanceof Nameable n) {
+        if (subject() instanceof Nameable) {
+            Nameable n = (Nameable) subject();
             return n.name();
         } else if (isConsole()) {
             return "Console";

--- a/sponge/src/main/java/revxrsal/commands/sponge/exception/SpongeExceptionHandler.java
+++ b/sponge/src/main/java/revxrsal/commands/sponge/exception/SpongeExceptionHandler.java
@@ -39,11 +39,15 @@ public class SpongeExceptionHandler extends DefaultExceptionHandler<SpongeComman
 
     @Override public void onInputParse(@NotNull InputParseException e, @NotNull SpongeCommandActor actor) {
         switch (e.cause()) {
-            case INVALID_ESCAPE_CHARACTER ->
-                    actor.error(legacyColorize("&cInvalid input. Use &e\\\\ &cto include a backslash."));
-            case UNCLOSED_QUOTE -> actor.error(legacyColorize("&cUnclosed quote. Make sure to close all quotes."));
-            case EXPECTED_WHITESPACE ->
-                    actor.error(legacyColorize("&cExpected whitespace to end one argument, but found trailing data."));
+            case INVALID_ESCAPE_CHARACTER:
+                actor.error(legacyColorize("&cInvalid input. Use &e\\\\ &cto include a backslash."));
+                break;
+            case UNCLOSED_QUOTE:
+                actor.error(legacyColorize("&cUnclosed quote. Make sure to close all quotes."));
+                break;
+            case EXPECTED_WHITESPACE:
+                actor.error(legacyColorize("&cExpected whitespace to end one argument, but found trailing data."));
+                break;
         }
     }
 

--- a/velocity/src/main/java/revxrsal/commands/velocity/actor/BasicActorFactory.java
+++ b/velocity/src/main/java/revxrsal/commands/velocity/actor/BasicActorFactory.java
@@ -29,21 +29,59 @@ import org.jetbrains.annotations.NotNull;
 import revxrsal.commands.Lamp;
 import revxrsal.commands.process.MessageSender;
 
+import java.util.Objects;
+
 /**
  * Default implementation of {@link ActorFactory}
  */
-record BasicActorFactory(
-        MessageSender<VelocityCommandActor, ComponentLike> messageSender,
-        MessageSender<VelocityCommandActor, ComponentLike> errorSender
-) implements ActorFactory<VelocityCommandActor> {
+final class BasicActorFactory implements ActorFactory<VelocityCommandActor> {
 
     public static final ActorFactory<VelocityCommandActor> INSTANCE = new BasicActorFactory(
             VelocityCommandActor::sendRawMessage,
             VelocityCommandActor::sendRawError
     );
+    private final MessageSender<VelocityCommandActor, ComponentLike> messageSender;
+    private final MessageSender<VelocityCommandActor, ComponentLike> errorSender;
+
+    /**
+     *
+     */
+    BasicActorFactory(
+            MessageSender<VelocityCommandActor, ComponentLike> messageSender,
+            MessageSender<VelocityCommandActor, ComponentLike> errorSender
+    ) {
+        this.messageSender = messageSender;
+        this.errorSender = errorSender;
+    }
 
     @Override
     public @NotNull VelocityCommandActor create(@NotNull CommandSource sender, @NotNull Lamp<VelocityCommandActor> lamp) {
         return new BasicVelocityActor(sender, lamp, messageSender, errorSender);
     }
+
+    public MessageSender<VelocityCommandActor, ComponentLike> messageSender() {return messageSender;}
+
+    public MessageSender<VelocityCommandActor, ComponentLike> errorSender() {return errorSender;}
+
+    @Override
+    public boolean equals(Object obj) {
+        if (obj == this) return true;
+        if (obj == null || obj.getClass() != this.getClass()) return false;
+        BasicActorFactory that = (BasicActorFactory) obj;
+        return Objects.equals(this.messageSender, that.messageSender) &&
+                Objects.equals(this.errorSender, that.errorSender);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(messageSender, errorSender);
+    }
+
+    @Override
+    public String toString() {
+        return "BasicActorFactory[" +
+                "messageSender=" + messageSender + ", " +
+                "errorSender=" + errorSender + ']';
+    }
+
 }

--- a/velocity/src/main/java/revxrsal/commands/velocity/actor/BasicVelocityActor.java
+++ b/velocity/src/main/java/revxrsal/commands/velocity/actor/BasicVelocityActor.java
@@ -8,16 +8,28 @@ import revxrsal.commands.Lamp;
 import revxrsal.commands.process.MessageSender;
 
 import java.nio.charset.StandardCharsets;
+import java.util.Objects;
 import java.util.UUID;
 
-record BasicVelocityActor(
-        CommandSource sender,
-        Lamp<VelocityCommandActor> lamp,
-        MessageSender<VelocityCommandActor, ComponentLike> messageSender,
-        MessageSender<VelocityCommandActor, ComponentLike> errorSender
-) implements VelocityCommandActor {
+final class BasicVelocityActor implements VelocityCommandActor {
 
     private static final UUID CONSOLE_UUID = new UUID(0, 0);
+    private final CommandSource sender;
+    private final Lamp<VelocityCommandActor> lamp;
+    private final MessageSender<VelocityCommandActor, ComponentLike> messageSender;
+    private final MessageSender<VelocityCommandActor, ComponentLike> errorSender;
+
+    BasicVelocityActor(
+            CommandSource sender,
+            Lamp<VelocityCommandActor> lamp,
+            MessageSender<VelocityCommandActor, ComponentLike> messageSender,
+            MessageSender<VelocityCommandActor, ComponentLike> errorSender
+    ) {
+        this.sender = sender;
+        this.lamp = lamp;
+        this.messageSender = messageSender;
+        this.errorSender = errorSender;
+    }
 
     @Override public @NotNull CommandSource source() {
         return sender;
@@ -43,4 +55,36 @@ record BasicVelocityActor(
     @Override public Lamp<VelocityCommandActor> lamp() {
         return lamp;
     }
+
+    public CommandSource sender() {return sender;}
+
+    public MessageSender<VelocityCommandActor, ComponentLike> messageSender() {return messageSender;}
+
+    public MessageSender<VelocityCommandActor, ComponentLike> errorSender() {return errorSender;}
+
+    @Override
+    public boolean equals(Object obj) {
+        if (obj == this) return true;
+        if (obj == null || obj.getClass() != this.getClass()) return false;
+        BasicVelocityActor that = (BasicVelocityActor) obj;
+        return Objects.equals(this.sender, that.sender) &&
+                Objects.equals(this.lamp, that.lamp) &&
+                Objects.equals(this.messageSender, that.messageSender) &&
+                Objects.equals(this.errorSender, that.errorSender);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(sender, lamp, messageSender, errorSender);
+    }
+
+    @Override
+    public String toString() {
+        return "BasicVelocityActor[" +
+                "sender=" + sender + ", " +
+                "lamp=" + lamp + ", " +
+                "messageSender=" + messageSender + ", " +
+                "errorSender=" + errorSender + ']';
+    }
+
 }

--- a/velocity/src/main/java/revxrsal/commands/velocity/exception/VelocityExceptionHandler.java
+++ b/velocity/src/main/java/revxrsal/commands/velocity/exception/VelocityExceptionHandler.java
@@ -34,11 +34,15 @@ public class VelocityExceptionHandler extends DefaultExceptionHandler<VelocityCo
 
     @Override public void onInputParse(@NotNull InputParseException e, @NotNull VelocityCommandActor actor) {
         switch (e.cause()) {
-            case INVALID_ESCAPE_CHARACTER ->
-                    actor.error(legacyColorize("&cInvalid input. Use &e\\\\ &cto include a backslash."));
-            case UNCLOSED_QUOTE -> actor.error(legacyColorize("&cUnclosed quote. Make sure to close all quotes."));
-            case EXPECTED_WHITESPACE ->
-                    actor.error(legacyColorize("&cExpected whitespace to end one argument, but found trailing data."));
+            case INVALID_ESCAPE_CHARACTER:
+                actor.error(legacyColorize("&cInvalid input. Use &e\\\\ &cto include a backslash."));
+                break;
+            case UNCLOSED_QUOTE:
+                actor.error(legacyColorize("&cUnclosed quote. Make sure to close all quotes."));
+                break;
+            case EXPECTED_WHITESPACE:
+                actor.error(legacyColorize("&cExpected whitespace to end one argument, but found trailing data."));
+                break;
         }
     }
 

--- a/velocity/src/main/java/revxrsal/commands/velocity/hooks/VelocityCommandHooks.java
+++ b/velocity/src/main/java/revxrsal/commands/velocity/hooks/VelocityCommandHooks.java
@@ -29,7 +29,6 @@ import com.velocitypowered.api.command.BrigadierCommand;
 import com.velocitypowered.api.command.CommandSource;
 import org.jetbrains.annotations.NotNull;
 import revxrsal.commands.Lamp;
-import revxrsal.commands.brigadier.BrigadierAdapter;
 import revxrsal.commands.brigadier.BrigadierConverter;
 import revxrsal.commands.brigadier.BrigadierParser;
 import revxrsal.commands.command.ExecutableCommand;

--- a/velocity/src/main/java/revxrsal/commands/velocity/parameters/PlayerParameterType.java
+++ b/velocity/src/main/java/revxrsal/commands/velocity/parameters/PlayerParameterType.java
@@ -34,6 +34,7 @@ import revxrsal.commands.stream.MutableStringStream;
 import revxrsal.commands.velocity.actor.VelocityCommandActor;
 import revxrsal.commands.velocity.exception.InvalidPlayerException;
 
+import java.util.Objects;
 import java.util.Optional;
 
 import static revxrsal.commands.util.Collections.map;
@@ -44,7 +45,13 @@ import static revxrsal.commands.util.Collections.map;
  * If the player inputs {@code me} or {@code self} or {@code @s}, the parser will
  * return the executing player (or give an error if the sender is not a player)
  */
-public record PlayerParameterType(@NotNull ProxyServer server) implements ParameterType<VelocityCommandActor, Player> {
+public final class PlayerParameterType implements ParameterType<VelocityCommandActor, Player> {
+    private final @NotNull ProxyServer server;
+
+    /**
+     *
+     */
+    public PlayerParameterType(@NotNull ProxyServer server) {this.server = server;}
 
     @Override
     public Player parse(@NotNull MutableStringStream input, @NotNull ExecutionContext<VelocityCommandActor> context) {
@@ -60,4 +67,26 @@ public record PlayerParameterType(@NotNull ProxyServer server) implements Parame
     @Override public @NotNull SuggestionProvider<VelocityCommandActor> defaultSuggestions() {
         return (context) -> map(server.getAllPlayers(), Player::getUsername);
     }
+
+    public @NotNull ProxyServer server() {return server;}
+
+    @Override
+    public boolean equals(Object obj) {
+        if (obj == this) return true;
+        if (obj == null || obj.getClass() != this.getClass()) return false;
+        PlayerParameterType that = (PlayerParameterType) obj;
+        return Objects.equals(this.server, that.server);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(server);
+    }
+
+    @Override
+    public String toString() {
+        return "PlayerParameterType[" +
+                "server=" + server + ']';
+    }
+
 }


### PR DESCRIPTION
This PR migrates Lamp v4 to Java 8. This has been motivated by the following reasons:
1. Personal use (I still prefer Java 8 :) )
2. Feedback from some users
3. Allow compatibility with platforms that do not support Java 9+
