### PR TITLE
Fix registering multiple orphans at once

### DIFF
--- a/common/src/main/java/revxrsal/commands/Lamp.java
+++ b/common/src/main/java/revxrsal/commands/Lamp.java
@@ -302,7 +302,7 @@ public final class Lamp<A extends CommandActor> {
                 OrphanRegistry registry = (OrphanRegistry) instance;
                 commandClass = registry.handler().getClass();
                 instance = registry.handler();
-                return tree.register(commandClass, instance, registry.paths());
+                registered.addAll(tree.register(commandClass, instance, registry.paths()));
             }
 
             registered.addAll(tree.register(commandClass, instance));


### PR DESCRIPTION
When registering multiple OrphanCommands at once using the `Lamp#register` function, only the first one is actually registered because the function returns too soon.