### PR TITLE
Fixed orphan commands registration

### DIFF
--- a/common/src/main/java/revxrsal/commands/Lamp.java
+++ b/common/src/main/java/revxrsal/commands/Lamp.java
@@ -303,9 +303,9 @@ public final class Lamp<A extends CommandActor> {
                 commandClass = registry.handler().getClass();
                 instance = registry.handler();
                 registered.addAll(tree.register(commandClass, instance, registry.paths()));
+            } else {
+                registered.addAll(tree.register(commandClass, instance));
             }
-
-            registered.addAll(tree.register(commandClass, instance));
         }
         return registered;
     }


### PR DESCRIPTION
Lamp tried to register orphan commands twice, both the handler and the command itself which caused "lack of parent command" exceptions.