### PR TITLE
Add condition to Minestom commands

### DIFF
--- a/minestom/src/main/java/revxrsal/commands/minestom/hooks/MinestomCommandHooks.java
+++ b/minestom/src/main/java/revxrsal/commands/minestom/hooks/MinestomCommandHooks.java
@@ -31,6 +31,7 @@ import net.minestom.server.command.builder.CommandExecutor;
 import net.minestom.server.command.builder.arguments.Argument;
 import net.minestom.server.command.builder.arguments.ArgumentLiteral;
 import net.minestom.server.command.builder.arguments.ArgumentType;
+import net.minestom.server.command.builder.condition.CommandCondition;
 import net.minestom.server.command.builder.exception.ArgumentSyntaxException;
 import net.minestom.server.command.builder.suggestion.SuggestionCallback;
 import net.minestom.server.command.builder.suggestion.SuggestionEntry;
@@ -77,6 +78,10 @@ public final class MinestomCommandHooks<A extends MinestomCommandActor> implemen
         String name = command.firstNode().name();
         Command minestomCommand = registeredRootNames.computeIfAbsent(name, k -> {
             Command c = new Command(k);
+            c.setCondition((sender, cmd) -> {
+                A actor = actorFactory.create(sender, command.lamp());
+                return command.permission().isExecutableBy(actor);
+            });
             MinecraftServer.getCommandManager().register(c);
             return c;
         });


### PR DESCRIPTION
Previously minestom commands would not check if the player could execute the command before sending the data to the player, so it would autofill. This should fix that.

I haven't worked in java in a while so I may have done something wrong but from my testing it does work.