### PR TITLE
Migrate to JDA v6.0.0

### DIFF
--- a/jda/build.gradle.kts
+++ b/jda/build.gradle.kts
@@ -8,5 +8,5 @@ repositories {
 
 dependencies {
     implementation(project(":common"))
-    compileOnly("net.dv8tion:JDA:5.1.0")
+    compileOnly("net.dv8tion:JDA:6.0.0-rc.1")
 }

--- a/jda/src/main/java/revxrsal/commands/jda/JDAVisitors.java
+++ b/jda/src/main/java/revxrsal/commands/jda/JDAVisitors.java
@@ -88,7 +88,7 @@ public final class JDAVisitors {
                         if (rename != null) {
                             SlashCommandData renamedData = parser.commands().get(rename);
                             if (renamedData != null) {
-                                jda.editCommandById(command.getId()).apply(renamedData).queue();
+                                jda.editCommandById(command.getType(), command.getId()).apply(renamedData).queue();
                                 notRegistered.remove(rename);
                             }
                         } else {
@@ -96,7 +96,7 @@ public final class JDAVisitors {
                             command.delete().queue();
                         }
                     } else {
-                        jda.editCommandById(command.getId()).apply(data).queue();
+                        jda.editCommandById(command.getType(), command.getId()).apply(data).queue();
                     }
                 }
                 notRegistered.values().forEach(newCommand ->

--- a/jda/src/main/java/revxrsal/commands/jda/actor/SlashCommandActor.java
+++ b/jda/src/main/java/revxrsal/commands/jda/actor/SlashCommandActor.java
@@ -24,6 +24,8 @@
 package revxrsal.commands.jda.actor;
 
 import net.dv8tion.jda.api.JDA;
+import net.dv8tion.jda.api.components.MessageTopLevelComponent;
+import net.dv8tion.jda.api.components.tree.ComponentTree;
 import net.dv8tion.jda.api.entities.Guild;
 import net.dv8tion.jda.api.entities.SelfUser;
 import net.dv8tion.jda.api.entities.User;
@@ -42,6 +44,8 @@ import org.jetbrains.annotations.Nullable;
 import revxrsal.commands.Lamp;
 import revxrsal.commands.command.CommandActor;
 import revxrsal.commands.jda.exception.GuildOnlyCommandException;
+
+import java.util.Collection;
 
 /**
  * Represents a {@link CommandActor} that originated from a {@link SlashCommandInteractionEvent slash command},
@@ -189,6 +193,55 @@ public interface SlashCommandActor extends CommandActor {
     @Contract(pure = true)
     default ReplyCallbackAction replyToInteraction(@NotNull MessageCreateData content) {
         return commandEvent().reply(content);
+    }
+
+    /**
+     * Reply to this interaction with one or more message components.
+     * <p>
+     * This can be used to send interactive elements such as buttons or select menus
+     * as the message content. The reply will also acknowledge the interaction.
+     *
+     * @param components The components to include in the reply
+     * @return {@link ReplyCallbackAction}
+     * @see IReplyCallback#replyComponents(Collection)
+     */
+    @CheckReturnValue
+    @Contract(pure = true)
+    default ReplyCallbackAction replyToInteraction(@NotNull Collection<? extends MessageTopLevelComponent> components) {
+        return commandEvent().replyComponents(components);
+    }
+
+    /**
+     * Reply to this interaction with one or more message components.
+     * <p>
+     * This is a varargs overload for convenience when sending multiple components.
+     * The reply will also acknowledge the interaction.
+     *
+     * @param component The first component to include in the reply
+     * @param other     Additional components to include
+     * @return {@link ReplyCallbackAction}
+     * @see IReplyCallback#replyComponents(MessageTopLevelComponent, MessageTopLevelComponent...)
+     */
+    @CheckReturnValue
+    @Contract(pure = true)
+    default ReplyCallbackAction replyToInteraction(@NotNull MessageTopLevelComponent component, @NotNull MessageTopLevelComponent... other) {
+        return commandEvent().replyComponents(component, other);
+    }
+
+    /**
+     * Reply to this interaction with a component tree.
+     * <p>
+     * This can be used to send structured components such as nested layouts.
+     * The reply will also acknowledge the interaction.
+     *
+     * @param tree The component tree to send
+     * @return {@link ReplyCallbackAction}
+     * @see IReplyCallback#replyComponents(ComponentTree)
+     */
+    @CheckReturnValue
+    @Contract(pure = true)
+    default ReplyCallbackAction replyToInteraction(@NotNull ComponentTree<? extends MessageTopLevelComponent> tree) {
+        return commandEvent().replyComponents(tree);
     }
 
     /**

--- a/jda/src/main/java/revxrsal/commands/jda/actor/SlashCommandActor.java
+++ b/jda/src/main/java/revxrsal/commands/jda/actor/SlashCommandActor.java
@@ -231,7 +231,7 @@ public interface SlashCommandActor extends CommandActor {
     /**
      * Reply to this interaction with a component tree.
      * <p>
-     * This can be used to send structured components such as nested layouts.
+     * Send a structured arrangement of interactive components.
      * The reply will also acknowledge the interaction.
      *
      * @param tree The component tree to send

--- a/jda/src/main/java/revxrsal/commands/jda/slash/JDAParser.java
+++ b/jda/src/main/java/revxrsal/commands/jda/slash/JDAParser.java
@@ -24,6 +24,7 @@
 package revxrsal.commands.jda.slash;
 
 import net.dv8tion.jda.api.Permission;
+import net.dv8tion.jda.api.interactions.InteractionContextType;
 import net.dv8tion.jda.api.interactions.commands.DefaultMemberPermissions;
 import net.dv8tion.jda.api.interactions.commands.build.Commands;
 import net.dv8tion.jda.api.interactions.commands.build.SlashCommandData;
@@ -57,7 +58,8 @@ public final class JDAParser<A extends SlashCommandActor> {
 
         SlashCommandData slash = slash(name, description);
         slash.setNSFW(executable.annotations().contains(NSFW.class));
-        slash.setGuildOnly(executable.annotations().contains(GuildOnly.class));
+        if (executable.annotations().contains(GuildOnly.class))
+            slash.setContexts(InteractionContextType.GUILD);
 
         String renameFrom = executable.annotations().map(RenameFrom.class, RenameFrom::value);
         if (renameFrom != null)


### PR DESCRIPTION
This PR brings the project in line with JDA V6.0.0-rc.1 by updating usages of deprecated methods introduced in the release candidate.

- Replaced `setGuild(boolean)` with `setContexts(InteractionContextType.GUILD)`
- Updated `editCommandById(id)` to `editCommandById(type, id)`

# Compatibility Notice
These changes are not backward compatible with JDA v5.x.x, as they rely on methods introduced in JDA v6.0.0-rc.1 or later.
Since v6 is still in RC, there might be more breaking changes before the final release. I would hold off on merging this until v6 is stable to avoid future conflicts.