### PR TITLE
fix: brigadier error when only optional flags and switches

### DIFF
--- a/brigadier/src/main/java/revxrsal/commands/brigadier/BrigadierParser.java
+++ b/brigadier/src/main/java/revxrsal/commands/brigadier/BrigadierParser.java
@@ -166,6 +166,8 @@ public final class BrigadierParser<S, A extends CommandActor> {
                     lastNode.then(child);
                 }
             }
+            if (flags.stream().allMatch(p -> p.isSwitch() || p.isOptional()))
+                lastNode.executes(createAction(command));
             return (LiteralCommandNode<S>) firstNode.asBrigadierNode();
         }
         List<BNode<S>> addOptionalsTo = new ArrayList<>();


### PR DESCRIPTION
Until now, calling commands having only optional flags and/or switches without specifying any of those flag or switch resulted in an "incomplete command" Brigadier error.

Fixes #137.

This is really blocking for commands that rely on switches. The only workaround is to create a separate command. I hope this fix handles all cases.