### PR TITLE
Fix Minestom command condition silently failing

### DIFF
--- a/minestom/src/main/java/revxrsal/commands/minestom/hooks/MinestomCommandHooks.java
+++ b/minestom/src/main/java/revxrsal/commands/minestom/hooks/MinestomCommandHooks.java
@@ -80,7 +80,13 @@ public final class MinestomCommandHooks<A extends MinestomCommandActor> implemen
             Command c = new Command(k);
             c.setCondition((sender, cmd) -> {
                 A actor = actorFactory.create(sender, command.lamp());
-                return command.permission().isExecutableBy(actor);
+                if (cmd == null) {
+                    // Minestom is checking whether to declare this command to the client
+                    return command.permission().isExecutableBy(actor);
+                } else {
+                    // For actual execution, command conditions should be left to run for user feedback
+                    return true;
+                }
             });
             MinecraftServer.getCommandManager().register(c);
             return c;


### PR DESCRIPTION
Currently Minestom commands behind a permission silently fail with no user feedback because Minestom's internal Command#addCondition blocks execution so Lamp's command conditions don't run.
This PR fixes that by only using Minestom's command condition to prevent declaring commands to client.