### PR TITLE
Let CommandPermission throw a custom exception

### DIFF
--- a/common/src/main/java/revxrsal/commands/command/CommandPermission.java
+++ b/common/src/main/java/revxrsal/commands/command/CommandPermission.java
@@ -27,6 +27,8 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import revxrsal.commands.Lamp;
 import revxrsal.commands.annotation.list.AnnotationList;
+import revxrsal.commands.exception.NoPermissionException;
+import revxrsal.commands.node.ExecutionContext;
 
 import java.lang.annotation.Annotation;
 import java.util.function.Function;
@@ -72,6 +74,14 @@ public interface CommandPermission<A extends CommandActor> extends Predicate<A> 
      */
     @Override default boolean test(A a) {
         return isExecutableBy(a);
+    }
+
+    /**
+     * Called when a command condition should be interrupted by lack of this permission.
+     * @param context Command context
+     */
+    default void throwMissingPermission(@NotNull ExecutionContext<A> context) {
+        throw new NoPermissionException(context.command());
     }
 
     /**

--- a/common/src/main/java/revxrsal/commands/command/PermissionConditionChecker.java
+++ b/common/src/main/java/revxrsal/commands/command/PermissionConditionChecker.java
@@ -25,7 +25,6 @@ package revxrsal.commands.command;
 
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
-import revxrsal.commands.exception.NoPermissionException;
 import revxrsal.commands.node.ExecutionContext;
 import revxrsal.commands.process.CommandCondition;
 
@@ -36,7 +35,8 @@ public enum PermissionConditionChecker implements CommandCondition<CommandActor>
 
     @Override
     public void test(@NotNull ExecutionContext<CommandActor> context) {
-        if (!context.command().permission().isExecutableBy(context.actor()))
-            throw new NoPermissionException(context.command());
+        if (!context.command().permission().isExecutableBy(context.actor())) {
+            context.command().permission().throwMissingPermission(context);
+        }
     }
 }


### PR DESCRIPTION
This lets a CommandPermission override the permission exception to throw when the internal PermissionConditionChecker fails the permission check.