### PR TITLE
Improve consistency of Bukkit exception handling messages

### DIFF
--- a/bukkit/src/main/java/revxrsal/commands/bukkit/exception/BukkitExceptionHandler.java
+++ b/bukkit/src/main/java/revxrsal/commands/bukkit/exception/BukkitExceptionHandler.java
@@ -105,7 +105,7 @@ public class BukkitExceptionHandler extends DefaultExceptionHandler<BukkitComman
     }
 
     @Override public void onInvalidUUID(@NotNull InvalidUUIDException e, @NotNull BukkitCommandActor actor) {
-        actor.error(legacyColorize("&cInvalid UUID: " + e.input() + "&c."));
+        actor.error(legacyColorize("&cInvalid UUID: &e" + e.input() + "&c."));
     }
 
     @Override
@@ -127,9 +127,9 @@ public class BukkitExceptionHandler extends DefaultExceptionHandler<BukkitComman
 
     @Override public void onInvalidHelpPage(@NotNull InvalidHelpPageException e, @NotNull BukkitCommandActor actor) {
         if (e.numberOfPages() == 1)
-            actor.error(legacyColorize("Invalid help page: &e" + e.page() + "&c. Must be 1."));
+            actor.error(legacyColorize("&cInvalid help page: &e" + e.page() + "&c. Must be 1."));
         else
-            actor.error(legacyColorize("Invalid help page: &e" + e.page() + "&c. Must be between &e1 &cand &e" + e.numberOfPages()));
+            actor.error(legacyColorize("&cInvalid help page: &e" + e.page() + "&c. Must be between &e1 &cand &e" + e.numberOfPages() + "&c."));
     }
 
     @Override public void onUnknownCommand(@NotNull UnknownCommandException e, @NotNull BukkitCommandActor actor) {
@@ -138,6 +138,6 @@ public class BukkitExceptionHandler extends DefaultExceptionHandler<BukkitComman
 
     @Override public void onValueNotAllowed(@NotNull ValueNotAllowedException e, @NotNull BukkitCommandActor actor) {
         String allowedValues = String.join("&c, &e", e.allowedValues());
-        actor.error(legacyColorize("Received an invalid value: &e" + e.input() + "&c. Allowed values: &e" + allowedValues + "&c."));
+        actor.error(legacyColorize("&cReceived an invalid value: &e" + e.input() + "&c. Allowed values: &e" + allowedValues + "&c."));
     }
 }

--- a/bukkit/src/main/java/revxrsal/commands/bukkit/exception/BukkitExceptionHandler.java
+++ b/bukkit/src/main/java/revxrsal/commands/bukkit/exception/BukkitExceptionHandler.java
@@ -20,7 +20,7 @@ public class BukkitExceptionHandler extends DefaultExceptionHandler<BukkitComman
     }
 
     @HandleException
-    public void onInvalidWorld(MissingLocationParameterException e, BukkitCommandActor actor) {
+    public void onMissingLocationParameter(MissingLocationParameterException e, BukkitCommandActor actor) {
         actor.error(legacyColorize("&cExpected &e" + e.axis().name().toLowerCase() + "&c."));
     }
 

--- a/bukkit/src/main/java/revxrsal/commands/bukkit/exception/BukkitExceptionHandler.java
+++ b/bukkit/src/main/java/revxrsal/commands/bukkit/exception/BukkitExceptionHandler.java
@@ -140,4 +140,15 @@ public class BukkitExceptionHandler extends DefaultExceptionHandler<BukkitComman
         String allowedValues = String.join("&c, &e", e.allowedValues());
         actor.error(legacyColorize("&cReceived an invalid value: &e" + e.input() + "&c. Allowed values: &e" + allowedValues + "&c."));
     }
+
+    @Override public void onUnknownParameter(@NotNull UnknownParameterException e, @NotNull BukkitCommandActor actor) {
+        if (e.shorthand())
+            actor.error(legacyColorize("&cUnknown shorthand flag: &e" + e.name() + "&c."));
+        else
+            actor.error(legacyColorize("&cUnknown flag: &e" + e.name() + "&c."));
+    }
+
+    @Override public void onCooldown(@NotNull CooldownException e, @NotNull BukkitCommandActor actor) {
+        actor.error(legacyColorize("&cYou must wait &e" + formatTimeFancy(e.getTimeLeftMillis()) + " &cbefore using this command again."));
+    }
 }


### PR DESCRIPTION
Refactored an incorrectly named method (no functional impact, but potentially breaking for developers who are already overriding with the incorrect name) and made the coloring of exception messages more consistent on the Bukkit platform.