### PR TITLE
fix: sibling detection false positive when prefix

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -16,7 +16,7 @@ plugins {
 }
 
 group = "io.github.revxrsal"
-version = "4.0.0-rc.14"
+version = "4.0.0-rc.15"
 
 java {
     toolchain {

--- a/common/build.gradle.kts
+++ b/common/build.gradle.kts
@@ -3,8 +3,8 @@ plugins {
 }
 
 dependencies {
-    testImplementation(platform("org.junit:junit-bom:5.10.0"))
-    testImplementation("org.junit.jupiter:junit-jupiter")
+    testImplementation("org.junit.jupiter:junit-jupiter:5.14.2")
+    testRuntimeOnly("org.junit.platform:junit-platform-launcher")
     compileOnly(kotlin("stdlib-jdk8"))
 }
 

--- a/common/src/test/java/revxrsal/commands/command/ExecutableCommandHelpTest.java
+++ b/common/src/test/java/revxrsal/commands/command/ExecutableCommandHelpTest.java
@@ -1,0 +1,94 @@
+package revxrsal.commands.command;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import revxrsal.commands.Lamp;
+import revxrsal.commands.annotation.Command;
+import revxrsal.commands.annotation.CommandPlaceholder;
+import revxrsal.commands.annotation.Subcommand;
+import revxrsal.commands.help.Help;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.stream.Collectors;
+
+class ExecutableCommandHelpTest {
+
+    private Lamp<CommandActor> lamp;
+
+    @BeforeEach
+    void setUp() {
+        lamp = Lamp.builder().build();
+    }
+
+    @Test
+    void testSiblingCommands() {
+        lamp.register(new CommandA(), new CommandB());
+        ExecutableCommand<CommandActor> commandA = getCommand("a");
+        ExecutableCommand<CommandActor> commandAA = getCommand("a a");
+        ExecutableCommand<CommandActor> commandB = getCommand("b");
+
+        assertPathsEquals(commandAA.siblingCommands(), "a b", "a");
+        assertPathsEquals(commandA.siblingCommands(), "a a", "a b");
+        assertPathsEquals(commandB.siblingCommands());
+    }
+
+    @Test
+    void testChildrenCommands() {
+        lamp.register(new CommandA(), new CommandB());
+        ExecutableCommand<CommandActor> commandA = getCommand("a");
+        ExecutableCommand<CommandActor> commandAA = getCommand("a a");
+        ExecutableCommand<CommandActor> commandB = getCommand("b");
+
+        assertPathsEquals(commandAA.childrenCommands());
+        assertPathsEquals(commandA.childrenCommands(), "a a", "a b");
+        assertPathsEquals(commandB.childrenCommands());
+    }
+
+    @Test
+    void testRelatedCommands() {
+        lamp.register(new CommandA(), new CommandB());
+        ExecutableCommand<CommandActor> commandA = getCommand("a");
+        ExecutableCommand<CommandActor> commandAA = getCommand("a a");
+        ExecutableCommand<CommandActor> commandB = getCommand("b");
+
+        assertPathsEquals(commandAA.relatedCommands(), "a b", "a");
+        assertPathsEquals(commandA.relatedCommands(), "a a", "a b");
+        assertPathsEquals(commandB.relatedCommands());
+    }
+
+    private ExecutableCommand<CommandActor> getCommand(String path) {
+        return lamp.registry().commands().stream().filter(cmd -> cmd.path().equals(path))
+                .findFirst().get();
+    }
+
+    private static void assertPathsEquals(Help.CommandList<CommandActor> commands,
+            String... paths) {
+        // we use sets here because we don't care about ordering
+        assertEquals(new HashSet<>(Arrays.asList(paths)),
+                commands.all().stream().map(cmd -> cmd.path()).collect(Collectors.toSet()));
+    }
+
+    @Command("a")
+    class CommandA {
+
+        @CommandPlaceholder
+        public void placeholder() {}
+
+        @Subcommand("a")
+        public void a() {}
+
+        @Subcommand("b")
+        public void b() {}
+
+    }
+
+    @Command("b")
+    class CommandB {
+
+        @CommandPlaceholder
+        public void b() {}
+
+    }
+
+}


### PR DESCRIPTION
Examples of fixed siblings:
- `bq help` has siblings `bq test` AND `bquests test`, since `bquests` starts with `bq` (but it's a coincidence). This has been fixed by changing the siblingPath from a simple String to an array of Strings.
- `bq help` has sibling `someCommand [something]` since initially the siblingPath of `someCommand [something]` was the empty string. This has been fixed by setting the siblingPath to the first node literal when it only contains one (so, when the command is a "top-level" command).

This closes #114.