### PR TITLE
build: fixed velocity repository

### DIFF
--- a/velocity/build.gradle.kts
+++ b/velocity/build.gradle.kts
@@ -3,7 +3,7 @@ plugins {
 }
 
 repositories {
-    maven(url = "https://nexus.velocitypowered.com/repository/maven-public/")
+    maven(url = "https://repo.papermc.io/repository/maven-public/")
 }
 
 dependencies {


### PR DESCRIPTION
`gradle build` on all modules failed due to the velocity module failing to fetch the dependencies (cf https://github.com/Revxrsal/Lamp/actions/runs/21741443564). The repository used is obsolete, this commit updates it to the newer version.