### PR TITLE
Fix default failure handling so unauthorized subcommands are not exposed in "Did you mean" suggestions

### DIFF
--- a/common/src/main/java/revxrsal/commands/node/DefaultFailureHandler.java
+++ b/common/src/main/java/revxrsal/commands/node/DefaultFailureHandler.java
@@ -4,14 +4,17 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Unmodifiable;
 import revxrsal.commands.Lamp;
 import revxrsal.commands.command.CommandActor;
+import revxrsal.commands.command.ExecutableCommand;
 import revxrsal.commands.command.Potential;
 import revxrsal.commands.exception.ExpectedLiteralException;
-import revxrsal.commands.exception.NoPermissionException;
+import revxrsal.commands.exception.UnknownCommandException;
+import revxrsal.commands.exception.context.ErrorContext;
+import revxrsal.commands.node.ExecutionContext;
 import revxrsal.commands.stream.StringStream;
 
+import java.util.ArrayList;
 import java.util.List;
 
-import static revxrsal.commands.util.Collections.any;
 import static revxrsal.commands.util.Collections.filter;
 
 /**
@@ -37,22 +40,74 @@ final class DefaultFailureHandler<A extends CommandActor> implements FailureHand
         if (failedAttempts.isEmpty()) {
             return;
         }
+
+        List<Potential<A>> visibleAttempts = filter(failedAttempts, attempt -> attempt.context().command().isVisibleTo(actor));
+        for (Potential<A> potential : failedAttempts) {
+            if (!potential.context().command().permission().isExecutableBy(actor)
+                    && !(potential.error() instanceof ExpectedLiteralException)) {
+                handleNoPermission(potential.context());
+                return;
+            }
+        }
+
+        if (visibleAttempts.size() > 1) {
+            List<String> suggestions = new ArrayList<>(visibleAttempts.size());
+            for (Potential<A> attempt : visibleAttempts) {
+                suggestions.add(attempt.context().command().path());
+            }
+            showSuggestions(actor, input, suggestions);
+            return;
+        }
+
+        if (visibleAttempts.size() == 1) {
+            Potential<A> visibleAttempt = visibleAttempts.get(0);
+            List<ExecutableCommand<A>> related = visibleAttempt.context().command().relatedCommands(actor).all();
+            if (!related.isEmpty()) {
+                List<String> suggestions = new ArrayList<>(related.size() + 1);
+                suggestions.add(visibleAttempt.context().command().path());
+                for (ExecutableCommand<A> command : related) {
+                    suggestions.add(command.path());
+                }
+                showSuggestions(actor, input, suggestions);
+                return;
+            }
+            visibleAttempt.handleException();
+            return;
+        }
+
+        for (Potential<A> potential : failedAttempts) {
+            if (!potential.context().command().permission().isExecutableBy(actor)) {
+                handleNoPermission(potential.context());
+                return;
+            }
+        }
+
         if (failedAttempts.size() == 1) {
             failedAttempts.get(0).handleException();
             return;
         }
 
-        List<Potential<A>> realExceptions = filter(failedAttempts, v -> !(v.error() instanceof ExpectedLiteralException));
-        if (realExceptions.isEmpty()) {
-            actor.error("Failed to find a suitable command for your input (\"" + input.source() + "\"). Did you mean:");
-            for (int i = 0; i < failedAttempts.size(); i++) {
-                if (i >= MAX_NUMBER_OF_SUGGESTIONS)
-                    break;
-                Potential<A> failedAttempt = failedAttempts.get(i);
-                actor.reply("- " + failedAttempt.context().command().path());
-            }
-        } else {
-            realExceptions.get(0).handleException();
+        lamp(failedAttempts).handleException(new UnknownCommandException(input.peekUnquotedString()), ErrorContext.unknownCommand(actor));
+    }
+
+    private void handleNoPermission(@NotNull ExecutionContext<A> context) {
+        try {
+            context.command().permission().throwMissingPermission(context);
+        } catch (Throwable throwable) {
+            context.lamp().handleException(throwable, ErrorContext.executingFunction(context));
+        }
+    }
+
+    private Lamp<A> lamp(@NotNull List<Potential<A>> failedAttempts) {
+        return failedAttempts.get(0).context().lamp();
+    }
+
+    private void showSuggestions(@NotNull A actor, @NotNull StringStream input, @NotNull List<String> commands) {
+        actor.error("Failed to find a suitable command for your input (\"" + input.source() + "\"). Did you mean:");
+        for (int i = 0; i < commands.size(); i++) {
+            if (i >= MAX_NUMBER_OF_SUGGESTIONS)
+                break;
+            actor.reply("- " + commands.get(i));
         }
     }
 }


### PR DESCRIPTION
1. Register multiple subcommands under the same root, and give the test player no permission for at least one of them.
2. Join with a normal player account and input the root command incorrectly or incompletely.
3. Before this fix, the failure message could include unauthorized subcommands in Failed to find a suitable command
     for your input... Did you mean:.
4. After this fix, only commands visible to the player are suggested.