### PR TITLE
Fix flag parser to handle negative numbers

### DIFF
--- a/common/src/main/java/revxrsal/commands/node/parser/FlagParser.java
+++ b/common/src/main/java/revxrsal/commands/node/parser/FlagParser.java
@@ -80,14 +80,19 @@ final class FlagParser<A extends CommandActor> {
                     int end = input.position();
                     rangesToRemove.add(new StringRange(start, end));
                 } else if (next.startsWith(SHORT_FORMAT_PREFIX)) {
-                    input.readUnquotedString();
-                    char[] flags = next.substring(SHORT_FORMAT_PREFIX.length()).toCharArray();
-                    for (char flag : flags) {
-                        ParameterNode<A, Object> parameter = removeParameterWithShorthand(flag);
-                        parseNext(context, parameter);
+                    String afterDash = next.substring(SHORT_FORMAT_PREFIX.length());
+                    if (!afterDash.isEmpty() && (Character.isDigit(afterDash.charAt(0)) || afterDash.charAt(0) == '.')) {
+                        input.moveForward(next.length());
+                    } else {
+                        input.readUnquotedString();
+                        char[] flags = afterDash.toCharArray();
+                        for (char flag : flags) {
+                            ParameterNode<A, Object> parameter = removeParameterWithShorthand(flag);
+                            parseNext(context, parameter);
+                        }
+                        int end = input.position();
+                        rangesToRemove.add(new StringRange(start, end));
                     }
-                    int end = input.position();
-                    rangesToRemove.add(new StringRange(start, end));
                 } else {
                     input.moveForward(next.length());
                 }


### PR DESCRIPTION
This pull request refines the parsing logic for short flag formats in the `FlagParser` class. The main improvement ensures that short flags which are actually numbers (e.g., `-1`, `-.5`) are not incorrectly interpreted as flag groups.

Flag parsing improvements:

* Updated the short flag parsing in `FlagParser.java` to check if the flag after the dash is a digit or a dot, and if so, treats it as a value rather than a group of flags. This prevents misparsing numeric arguments as flag groups.